### PR TITLE
docs: update links to use magic.fluttersdk.com absolute URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,15 +424,15 @@ Full docs at **[magic.fluttersdk.com](https://magic.fluttersdk.com)**.
 
 | Topic | |
 |-------|--|
-| [Installation](doc/getting-started/installation.md) | Setup and requirements |
-| [Configuration](doc/getting-started/configuration.md) | Environment and config files |
-| [Service Providers](doc/getting-started/service-providers.md) | Provider lifecycle |
-| [Routing](doc/basics/routing.md) | Routes and navigation |
-| [Controllers](doc/basics/controllers.md) | Request handlers |
-| [Views](doc/basics/views.md) | UI layer |
-| [HTTP Client](doc/basics/http-client.md) | Network requests |
-| [Middleware](doc/basics/middleware.md) | Request pipeline |
-| [Forms](doc/basics/forms.md) | Form handling and validation |
+| [Installation](https://magic.fluttersdk.com/getting-started/installation) | Setup and requirements |
+| [Configuration](https://magic.fluttersdk.com/getting-started/configuration) | Environment and config files |
+| [Service Providers](https://magic.fluttersdk.com/getting-started/service-providers) | Provider lifecycle |
+| [Routing](https://magic.fluttersdk.com/basics/routing) | Routes and navigation |
+| [Controllers](https://magic.fluttersdk.com/basics/controllers) | Request handlers |
+| [Views](https://magic.fluttersdk.com/basics/views) | UI layer |
+| [HTTP Client](https://magic.fluttersdk.com/basics/http-client) | Network requests |
+| [Middleware](https://magic.fluttersdk.com/basics/middleware) | Request pipeline |
+| [Forms](https://magic.fluttersdk.com/basics/forms) | Form handling and validation |
 
 ## AI Agent Integration
 

--- a/example/lib/resources/views/welcome_view.dart
+++ b/example/lib/resources/views/welcome_view.dart
@@ -75,7 +75,8 @@ class WelcomeView extends StatelessWidget {
                       title: 'Documentation',
                       description:
                           'Read the Magic Framework docs to get started.',
-                      url: 'https://magic.fluttersdk.com',
+                      url:
+                          'https://magic.fluttersdk.com/getting-started/installation',
                     ),
                     _buildLinkCard(
                       icon: Icons.code,
@@ -89,7 +90,7 @@ class WelcomeView extends StatelessWidget {
                       title: 'CLI Commands',
                       description:
                           'Run `magic --help` to see all available commands.',
-                      url: 'https://magic.fluttersdk.com/cli',
+                      url: 'https://magic.fluttersdk.com/packages/magic-cli',
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Summary

- README documentation table links updated from relative `doc/` paths to absolute `https://magic.fluttersdk.com/` URLs
- Example app welcome view Documentation card now points to `/getting-started/installation`
- Example app CLI card now points to `/packages/magic-cli`

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 453 tests passed