### PR TITLE
docs(skill): add ecosystem plugin references

### DIFF
--- a/skills/magic-framework/SKILL.md
+++ b/skills/magic-framework/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: magic-framework
-description: "Magic Framework -- Laravel-inspired Flutter framework with IoC Container, Facades, Eloquent ORM, Service Providers, and GoRouter wrapper. ALWAYS activate for: Magic.init, MagicApp, MagicController, MagicView, MagicStatefulView, MagicStatefulViewState, MagicResponsiveView, MagicFormData, MagicForm, MagicBuilder, MagicRoute, MagicResponse, Eloquent Model, InteractsWithPersistence, HasTimestamps, ServiceProvider, MagicMiddleware, MagicStateMixin, ValidatesRequests, RxStatus, SimpleMagicController, Auth facade, Http facade, Config facade, Cache facade, DB facade, Gate facade, Log facade, Event facade, Lang facade, Schema facade, Vault facade, Storage facade, Pick facade, Crypt facade, Launch facade, Route facade, MagicCan, MagicCannot, MagicApplication, MagicAppWidget, MagicRouterOutlet, RouteServiceProvider, Kernel, Magic.findOrPut, Magic.make, Magic.bind, Magic.singleton, Magic.put, Magic.find, Magic.delete, Magic.snackbar, Magic.success, Magic.error, Magic.toast, Magic.confirm, Magic.dialog, Magic.loading, Magic.closeLoading, Magic.reload, Magic.seed, Magic.flush, Magic.view, Carbon, trans(), env(), rules(), handleApiError, setErrorsFromResponse, MagicViewRegistry, MagicFeedback, dart run magic:magic, magic install, make:model, make:controller, make:view, make:migration, make:enum, make:event, make:listener, make:middleware, make:factory, make:seeder, make:provider, make:policy, make:request, make:lang, key:generate. Use for ANY Flutter project built on the Magic framework."
+description: "Magic Framework -- Laravel-inspired Flutter framework with IoC Container, Facades, Eloquent ORM, Service Providers, and GoRouter wrapper. ALWAYS activate for: Magic.init, MagicApp, MagicController, MagicView, MagicStatefulView, MagicStatefulViewState, MagicResponsiveView, MagicFormData, MagicForm, MagicBuilder, MagicRoute, MagicResponse, Eloquent Model, InteractsWithPersistence, HasTimestamps, ServiceProvider, MagicMiddleware, MagicStateMixin, ValidatesRequests, RxStatus, SimpleMagicController, Auth facade, Http facade, Config facade, Cache facade, DB facade, Gate facade, Log facade, Event facade, Lang facade, Schema facade, Vault facade, Storage facade, Pick facade, Crypt facade, Launch facade, Route facade, MagicCan, MagicCannot, MagicApplication, MagicAppWidget, MagicRouterOutlet, RouteServiceProvider, Kernel, Magic.findOrPut, Magic.make, Magic.bind, Magic.singleton, Magic.put, Magic.find, Magic.delete, Magic.snackbar, Magic.success, Magic.error, Magic.toast, Magic.confirm, Magic.dialog, Magic.loading, Magic.closeLoading, Magic.reload, Magic.seed, Magic.flush, Magic.view, Carbon, trans(), env(), rules(), handleApiError, setErrorsFromResponse, MagicViewRegistry, MagicFeedback, dart run magic:magic, magic install, make:model, make:controller, make:view, make:migration, make:enum, make:event, make:listener, make:middleware, make:factory, make:seeder, make:provider, make:policy, make:request, make:lang, key:generate, magic_deeplink, DeeplinkManager, DeeplinkHandler, DeeplinkDriver, RouteDeeplinkHandler, magic_notifications, Notify, NotificationManager, DatabaseNotification, Notifiable, PushDriver, NotificationChannel, magic_social_auth, SocialAuth, SocialAuthManager, SocialDriver, SocialAuthButtons, SocialToken, magic_starter, MagicStarter, MagicStarterServiceProvider, MagicStarterViewRegistry. Use for ANY Flutter project built on the Magic framework."
 ---
 
 # Magic Framework
@@ -539,6 +539,28 @@ When you encounter a **genuine issue** during Magic framework work, suggest crea
 - If user says "don't report" or "not now" — respect it, don't re-suggest
 - Never auto-create without explicit user confirmation
 
+## 9.5. Ecosystem Plugins
+
+Official plugins extending Magic Framework. Each has its own package, service provider, and config.
+
+| Plugin | Package | Access | Purpose |
+|--------|---------|--------|---------|
+| Deep Link | `magic_deeplink` | `DeeplinkManager()` singleton | Universal Links (iOS) + App Links (Android) |
+| Notifications | `magic_notifications` | `Notify` facade | Push (OneSignal) + in-app notifications with polling |
+| Social Auth | `magic_social_auth` | `SocialAuth` facade | OAuth login (Google, Microsoft, GitHub) + custom drivers |
+| Starter Kit | `magic_starter` | `MagicStarter` facade | Pre-built auth, profile, teams, notifications screens |
+
+**Plugin suggestion rule**: When user attempts functionality covered by a plugin, check `pubspec.yaml` for the package. If missing, suggest it:
+
+| User Intent | Suggest | Note |
+|-------------|---------|------|
+| Deep linking, universal links, app links | `magic_deeplink` | |
+| Push/in-app notifications, notification polling | `magic_notifications` | |
+| Social login, Google/Microsoft/GitHub sign-in, OAuth | `magic_social_auth` | |
+| Starter kit, pre-built auth/profile/team screens | `magic_starter` | Includes `magic_notifications` — suggest only this if user needs both |
+
+**Suggestion format**: "This feature is provided by `{package}`. Add it with `flutter pub add {package}` and register its service provider. See `references/plugin-{name}.md` for details."
+
 ## 10. Reference Index
 
 | File | Content | Load When |
@@ -554,3 +576,7 @@ When you encounter a **genuine issue** during Magic framework work, suggest crea
 | `references/secondary-systems.md` | Cache, Events (EventDispatcher, register listeners), Logging, Localization (trans()), Storage, Encryption, Vault, Carbon date helper, Launch, Policies | Using caching, events, logging, i18n, file storage, encryption, or URL launching |
 | `references/testing-patterns.md` | Test setup (MagicApp.reset + Magic.flush), mocking via contracts, controller/model/middleware testing patterns | Writing tests for any Magic framework code |
 | `references/cli-commands.md` | Full CLI reference: install, all make:* generators with flags, key:generate | Scaffolding code, initializing projects, or generating files with the CLI |
+| `references/plugin-deeplink.md` | DeeplinkManager, handlers, drivers, config, RouteDeeplinkHandler, OneSignalDeeplinkHandler | Working with deep links, universal links, or app links |
+| `references/plugin-notifications.md` | Notify facade, channels (database, push), drivers (OneSignal), polling, DatabaseNotification, PushMessage | Implementing push or in-app notifications |
+| `references/plugin-social-auth.md` | SocialAuth facade, drivers (Google/Microsoft/GitHub), handlers, SocialAuthButtons widget | Adding social login or OAuth authentication |
+| `references/plugin-starter.md` | MagicStarter facade, 13 opt-in features, view registry, pre-built auth/profile/team/notification views | Using starter kit or pre-built screens |

--- a/skills/magic-framework/references/plugin-deeplink.md
+++ b/skills/magic-framework/references/plugin-deeplink.md
@@ -1,0 +1,290 @@
+# magic_deeplink Plugin
+
+Deep link handling plugin for Magic Framework — wraps `app_links` with a handler chain, IoC binding, and CLI tooling for generating server-side verification files.
+
+## Installation
+
+```bash
+dart run magic_deeplink install
+```
+
+Scaffolds `lib/config/deeplink.dart`, injects `DeeplinkServiceProvider` into `lib/config/app.dart`, and injects `deeplinkConfig` into `lib/main.dart`.
+
+## DeeplinkManager API
+
+No facade — accessed via singleton `DeeplinkManager()` or IoC `Magic.make<DeeplinkManager>('deeplinks')`.
+
+| Method / Property | Signature | Description |
+|:------------------|:----------|:------------|
+| `setDriver(driver)` | `void` | Set the active deep link driver. |
+| `forgetDriver()` | `void` | Remove the current driver (resets to null). |
+| `registerHandler(handler)` | `void` | Add a handler to the chain. Duplicates are ignored. |
+| `hasHandler(handler)` | `bool` | Check if a handler is registered. |
+| `forgetHandlers()` | `void` | Clear all registered handlers. |
+| `handleUri(uri)` | `Future<bool>` | Emit `uri` on `onLink` and delegate to first matching handler. Returns `true` if handled. |
+| `getInitialLink()` | `Future<Uri?>` | Get the URI that cold-launched the app (cached after first call). |
+| `onLink` | `Stream<Uri>` | Broadcast stream of all incoming links (fired before handler dispatch). |
+| `driver` | `DeeplinkDriver` | Getter — throws `DeeplinkException(code: 'NO_DRIVER')` if unset. |
+
+```dart
+import 'package:magic_deeplink/magic_deeplink.dart';
+
+final manager = DeeplinkManager();
+
+// Register a custom handler
+manager.registerHandler(MyCustomHandler());
+
+// Listen to all links (raw stream, before handlers)
+manager.onLink.listen((uri) {
+  print('Incoming link: $uri');
+});
+
+// Get initial link (cold launch)
+final initial = await manager.getInitialLink();
+if (initial != null) {
+  await manager.handleUri(initial);
+}
+```
+
+## Contracts
+
+### DeeplinkDriver
+
+Abstract contract for platform link providers.
+
+| Member | Type | Description |
+|:-------|:-----|:------------|
+| `name` | `String` | Driver identifier. |
+| `isSupported` | `bool` | Whether this driver works on the current platform. |
+| `initialize(config)` | `Future<void>` | Boot the driver with config map. |
+| `getInitialLink()` | `Future<Uri?>` | Return the cold-launch URI, if any. |
+| `onLink` | `Stream<Uri>` | Stream of subsequent incoming links. |
+| `dispose()` | `void` | Release resources. |
+
+### DeeplinkHandler
+
+Abstract contract for URI handlers. Handlers are tested in registration order — first match wins.
+
+| Member | Type | Description |
+|:-------|:-----|:------------|
+| `canHandle(uri)` | `bool` | Return `true` if this handler claims the URI. |
+| `handle(uri)` | `Future<bool>` | Process the URI. Return `true` on success. |
+
+```dart
+// Custom handler example
+class PaymentHandler extends DeeplinkHandler {
+  @override
+  bool canHandle(Uri uri) => uri.path.startsWith('/payment');
+
+  @override
+  Future<bool> handle(Uri uri) async {
+    final orderId = uri.queryParameters['order_id'];
+    Route.to('/payment/confirm', extra: {'orderId': orderId});
+    return true;
+  }
+}
+```
+
+## Built-in Implementations
+
+### AppLinksDriver
+
+Wraps the `app_links` package. Supports Android, iOS, and macOS. Not supported on web.
+
+- **Driver name**: `'app_links'`
+- **`isSupported`**: `true` on Android, iOS, macOS; `false` on web and other platforms.
+- Registered automatically by `DeeplinkServiceProvider` when `deeplink.driver` is `'app_links'`.
+
+### RouteDeeplinkHandler
+
+Maps URI path patterns to `MagicRoute.to()` navigation. Patterns support wildcards (`*`) and named segments (`:param`).
+
+```dart
+import 'package:magic_deeplink/magic_deeplink.dart';
+
+// Match specific paths
+final handler = RouteDeeplinkHandler(
+  paths: ['/products/:id', '/orders/*', '/promo/:code'],
+);
+DeeplinkManager().registerHandler(handler);
+```
+
+- Pattern `/products/:id` matches `/products/42` (`:param` matches one path segment).
+- Pattern `/orders/*` matches `/orders/any/nested/path` (`*` matches everything).
+- Matching is case-insensitive.
+- On match, navigates to `uri.path` and passes `uri.queryParameters`.
+
+### OneSignalDeeplinkHandler
+
+Auto-registered by `DeeplinkServiceProvider` when `magic_notifications` is bound in the IoC container. Extracts URIs from notification click payloads and feeds them into `DeeplinkManager.handleUri()`.
+
+Checks for URI under these payload keys in order: `'url'`, `'deep_link'`, `'link'`, `'uri'`.
+
+No manual registration needed when using `magic_notifications`.
+
+## Configuration
+
+Scaffolded to `lib/config/deeplink.dart` by `dart run magic_deeplink install`. The `ios` and `android` sub-keys are only read by `dart run magic_deeplink:generate` — they are not used at runtime.
+
+```dart
+Map<String, dynamic> get deeplinkConfig => {
+  'deeplink': {
+    'enabled': true,
+    'driver': 'app_links',          // Only built-in driver
+    'domain': 'example.com',        // Your web domain for universal/app links
+    'scheme': 'https',              // 'https' or custom scheme
+
+    'ios': {
+      'team_id': 'YOUR_TEAM_ID',    // Apple Developer Team ID
+      'bundle_id': 'com.example.app',
+    },
+
+    'android': {
+      'package_name': 'com.example.app',
+      'sha256_fingerprints': [
+        'YOUR_SHA256_FINGERPRINT',  // Colon-separated hex string
+      ],
+    },
+
+    'paths': [
+      '/*',                         // Patterns passed to generate command
+    ],
+  },
+};
+```
+
+## ServiceProvider
+
+`DeeplinkServiceProvider` is **NOT auto-registered** — add it explicitly or use `dart run magic_deeplink install` which does this automatically.
+
+**register()**: Binds `DeeplinkManager()` as a singleton under key `'deeplinks'`.
+
+**boot()**: Resolves driver from `deeplink.driver` config → initializes it → subscribes driver's `onLink` stream to `manager.handleUri()` → schedules `getInitialLink()` via `Future.delayed(Duration.zero)` (defers until after first frame so router is ready). Also auto-registers `OneSignalDeeplinkHandler` if `'notifications'` is bound.
+
+```dart
+// lib/config/app.dart
+import 'package:magic_deeplink/magic_deeplink.dart';
+
+final appConfig = {
+  'app': {
+    'providers': [
+      (app) => DeeplinkServiceProvider(app),
+    ],
+  },
+};
+```
+
+## CLI Commands
+
+### install
+
+```bash
+dart run magic_deeplink install
+dart run magic_deeplink install --force   # Overwrite existing config
+```
+
+Writes `lib/config/deeplink.dart`, injects `DeeplinkServiceProvider` into `lib/config/app.dart`, and injects `deeplinkConfig` factory into `lib/main.dart`.
+
+### generate
+
+```bash
+dart run magic_deeplink generate --output ./public
+dart run magic_deeplink generate \
+  --team-id ABCDE12345 \
+  --bundle-id com.example.app \
+  --package-name com.example.app \
+  --sha256-fingerprints AA:BB:CC:... \
+  --output public
+```
+
+Reads values from `lib/config/deeplink.dart` and merges with any CLI flags (flags take priority). Outputs:
+- `apple-app-site-association` — iOS Universal Links verification file.
+- `assetlinks.json` — Android App Links verification file.
+
+Upload both files to your web server's `/.well-known/` directory (or domain root for AASA).
+
+## Usage Patterns
+
+### Basic setup with route handler
+
+```dart
+import 'package:magic_deeplink/magic_deeplink.dart';
+
+class AppServiceProvider extends ServiceProvider {
+  @override
+  void register() {}
+
+  @override
+  Future<void> boot() async {
+    final manager = DeeplinkManager();
+
+    // Handle all paths defined in config
+    manager.registerHandler(
+      RouteDeeplinkHandler(paths: ['/products/:id', '/orders/:id', '/*']),
+    );
+  }
+}
+```
+
+### Custom handler with specific logic
+
+```dart
+class InviteHandler extends DeeplinkHandler {
+  @override
+  bool canHandle(Uri uri) => uri.path == '/invite' && uri.queryParameters.containsKey('code');
+
+  @override
+  Future<bool> handle(Uri uri) async {
+    final code = uri.queryParameters['code']!;
+    await Magic.make<InviteService>('invites').redeem(code);
+    Route.to('/welcome');
+    return true;
+  }
+}
+
+// Register specific handlers before catch-all
+manager.registerHandler(InviteHandler());
+manager.registerHandler(RouteDeeplinkHandler(paths: ['/*']));  // Catch-all last
+```
+
+### Listening to all links without intercepting
+
+```dart
+// Subscribe to raw link stream — does not affect handler chain
+DeeplinkManager().onLink.listen((uri) {
+  Log.info('Deep link received', {'uri': uri.toString()});
+});
+```
+
+## Testing
+
+```dart
+setUp(() {
+  MagicApp.reset();
+  Magic.flush();
+  DeeplinkManager().forgetHandlers();
+  DeeplinkManager().forgetDriver();
+});
+
+test('handles product deep link', () async {
+  final handler = RouteDeeplinkHandler(paths: ['/products/:id']);
+  DeeplinkManager().registerHandler(handler);
+
+  final handled = await DeeplinkManager().handleUri(
+    Uri.parse('https://example.com/products/42'),
+  );
+  expect(handled, isTrue);
+});
+```
+
+## Gotchas
+
+| Mistake | Fix |
+|:--------|:----|
+| Accessing `DeeplinkManager().driver` before provider boots | `DeeplinkServiceProvider` sets the driver in `boot()` — accessing `driver` before that throws `DeeplinkException(code: 'NO_DRIVER')` |
+| Initial link never handled | `getInitialLink()` is deferred via `Future.delayed(Duration.zero)` — router must be initialized before it fires |
+| Catch-all handler registered first | Handler chain is first-match-wins — register specific handlers before `RouteDeeplinkHandler(paths: ['/*'])` |
+| `OneSignalDeeplinkHandler` not activating | Requires `'notifications'` to be bound in IoC before `DeeplinkServiceProvider.boot()` runs — ensure provider order in `app.dart` |
+| `forgetHandlers()` skipped in tests | Always call `DeeplinkManager().forgetHandlers()` + `forgetDriver()` in `setUp()` — manager is a singleton |
+| `generate` command missing iOS output | Requires both `--team-id` and `--bundle-id` — skips AASA silently if either is missing |
+| `RouteDeeplinkHandler` `:param` not matching | `:param` matches a single path segment only — use `*` for multi-segment patterns |

--- a/skills/magic-framework/references/plugin-notifications.md
+++ b/skills/magic-framework/references/plugin-notifications.md
@@ -1,0 +1,358 @@
+# magic_notifications Plugin
+
+Push and in-app notification system for Magic Framework — provides the `Notify` facade, database (in-app) notifications with real-time streaming, OneSignal push integration, and background polling.
+
+**Package**: `magic_notifications` v0.0.1-alpha.1 · **Install**: `dart run magic_notifications install`
+
+## Notify Facade API
+
+All methods are accessed via the static `Notify` facade after importing `package:magic_notifications/magic_notifications.dart`.
+
+### Sending
+
+| Method | Parameters | Return Type | Description |
+|:-------|:-----------|:------------|:------------|
+| `Notify.send(notifiable, notification)` | `Notifiable notifiable`, `Notification notification` | `Future<void>` | Send notification to entity through channels defined by `notification.via()`. |
+
+### Database (In-App) Notifications
+
+| Method | Parameters | Return Type | Description |
+|:-------|:-----------|:------------|:------------|
+| `Notify.notifications()` | — | `Stream<List<DatabaseNotification>>` | Broadcast stream — emits current cache immediately, then re-emits on every fetch/read/delete. |
+| `Notify.fetchNotifications()` | — | `Future<void>` | Fetch from `GET /notifications` and push updated list to stream. |
+| `Notify.refreshNotifications()` | — | `Future<void>` | Alias for `fetchNotifications()`. |
+| `Notify.fetchPaginatedNotifications({page, perPage})` | `int page = 1`, `int perPage = 15` | `Future<PaginatedNotifications>` | Returns paginated response with meta (current_page, last_page, total). |
+| `Notify.unreadCount()` | — | `Future<int>` | Fetch unread count from `GET /notifications/unread-count`. |
+| `Notify.markAsRead(id)` | `String id` | `Future<void>` | Optimistically mark read locally, then `POST /notifications/{id}/read`. Reverts on failure. |
+| `Notify.markAllAsRead()` | — | `Future<void>` | Optimistically mark all read locally, then `POST /notifications/read-all`. Reverts on failure. |
+| `Notify.deleteNotification(id)` | `String id` | `Future<void>` | Optimistically remove locally, then `DELETE /notifications/{id}`. Reverts on failure. |
+
+### Push Notifications
+
+| Method | Parameters | Return Type | Description |
+|:-------|:-----------|:------------|:------------|
+| `Notify.initializePush(userId)` | `String userId` | `Future<void>` | Associate logged-in user with push device. Call after `Auth.login()`. |
+| `Notify.requestPushPermission()` | — | `Future<bool>` | Show system permission dialog. Returns `true` if granted. |
+| `Notify.logoutPush()` | — | `Future<void>` | Unlink device from user account. Call before `Auth.logout()`. |
+
+### Polling
+
+| Method | Parameters | Return Type | Description |
+|:-------|:-----------|:------------|:------------|
+| `Notify.startPolling()` | — | `void` | Start 30-second polling. Fetches immediately on start. Idempotent. |
+| `Notify.stopPolling()` | — | `void` | Stop polling and destroy timer. Call on logout. |
+| `Notify.pausePolling()` | — | `void` | Pause (timer keeps running, fetches are skipped). Use on app background. |
+| `Notify.resumePolling()` | — | `void` | Resume paused polling. Fetches immediately on resume. |
+
+### Manager Access
+
+```dart
+final manager = Notify.manager; // NotificationManager singleton
+```
+
+## Contracts
+
+### Notification (abstract)
+
+Extend to define a notification type.
+
+```dart
+import 'package:magic_notifications/magic_notifications.dart';
+
+class MonitorDownNotification extends Notification {
+  final Monitor monitor;
+  MonitorDownNotification(this.monitor);
+
+  @override
+  List<String> via(Notifiable notifiable) => ['database', 'push'];
+
+  @override
+  Map<String, dynamic>? toDatabase(Notifiable notifiable) => {
+    'title': 'Monitor Down',
+    'body': '${monitor.name} is not responding',
+    'action_url': '/monitors/${monitor.id}',
+  };
+
+  @override
+  dynamic toPush(Notifiable notifiable) => PushMessage()
+    .heading('Monitor Down')
+    .content('${monitor.name} is not responding')
+    .url('/monitors/${monitor.id}');
+}
+```
+
+| Member | Type | Description |
+|:-------|:-----|:------------|
+| `type` | `String` (getter) | Defaults to `runtimeType.toString()`. Override to customize. |
+| `via(notifiable)` | `List<String>` | Required. Return channel names: `'database'`, `'push'`, `'mail'`. |
+| `toDatabase(notifiable)` | `Map<String, dynamic>?` | Return payload with `title`, `body`, optional `action_url`. |
+| `toPush(notifiable)` | `dynamic` | Return `PushMessage` instance or raw map. |
+| `toMail(notifiable)` | `dynamic` | Return mail payload (mail channel not auto-registered). |
+
+### Notifiable (mixin)
+
+Apply to any model that can receive notifications.
+
+```dart
+class User extends Model with Notifiable {
+  @override
+  String get notifiableId => getAttribute('id').toString();
+
+  @override
+  String? get notifiableEmail => getAttribute('email') as String?;
+}
+```
+
+| Member | Type | Description |
+|:-------|:-----|:------------|
+| `notifiableId` | `String` | Required. Unique identifier used to target the entity. |
+| `notifiableEmail` | `String?` | Optional. Used by mail channel. Defaults to `null`. |
+| `pushExternalId` | `String` | Push targeting ID. Defaults to `notifiableId`. |
+| `notificationPreference` | `dynamic` | Optional `NotificationPreference` instance. Defaults to `null`. |
+| `notify(notification)` | `Future<void>` | Convenience method — calls `NotificationManager().send(this, notification)`. |
+
+### NotificationChannel (abstract)
+
+Implement to create a custom channel.
+
+| Member | Type | Description |
+|:-------|:-----|:------------|
+| `name` | `String` | Channel identifier (e.g., `'database'`, `'push'`). |
+| `isAvailable` | `bool` | Whether the channel is configured and available. |
+| `send(notifiable, notification)` | `Future<void>` | Deliver the notification through this channel. |
+
+## Channels
+
+### DatabaseChannel (`'database'`)
+
+Stores notifications via `POST /notifications`. Reads `toDatabase()` from the notification. Returns early if `toDatabase()` returns `null`.
+
+### PushChannel (`'push'`)
+
+Sends push via the configured `PushDriver`. Uses `toPush()` from the notification. Skipped if `isAvailable` is `false` (no driver configured or not opted in).
+
+## PushDriver
+
+### PushDriver (abstract)
+
+| Member | Type | Description |
+|:-------|:-----|:------------|
+| `name` | `String` | Driver identifier (e.g., `'onesignal'`). |
+| `isSupported` | `bool` | Whether push is supported on this platform. |
+| `permissionState` | `PushPermissionState` | Current permission state. |
+| `isOptedIn` | `bool` | Whether user is opted in. |
+| `initialize(config)` | `Future<void>` | Initialize driver with config map. |
+| `login(externalId)` | `Future<void>` | Associate push subscription with user ID. |
+| `logout()` | `Future<void>` | Remove user association from push subscription. |
+| `requestPermission()` | `Future<bool>` | Show permission dialog. Returns grant result. |
+| `optIn()` | `Future<void>` | Opt user in to push. |
+| `optOut()` | `Future<void>` | Opt user out of push. |
+| `setTags(tags)` | `Future<void>` | Set targeting tags for segmentation. |
+| `removeTag(key)` | `Future<void>` | Remove a specific targeting tag. |
+| `onNotificationReceived` | `Stream<PushNotificationEvent>` | Fires when notification arrives in foreground. |
+| `onNotificationClicked` | `Stream<PushNotificationEvent>` | Fires when user taps notification. |
+| `onPermissionChanged` | `Stream<PushPermissionState>` | Fires when permission state changes. |
+
+`PushPermissionState` enum values: `notDetermined`, `denied`, `authorized`, `provisional`.
+
+### OneSignalDriver
+
+The built-in implementation. Auto-created by `NotificationServiceProvider` when `notifications.push.driver` is `'onesignal'`.
+
+## Models
+
+### DatabaseNotification
+
+Represents an in-app notification from the backend.
+
+| Property | Type | Description |
+|:---------|:-----|:------------|
+| `id` | `String` | Unique notification ID. |
+| `type` | `String` | Notification type string (e.g., `'MonitorDownNotification'`). |
+| `title` | `String` | Display title. |
+| `body` | `String` | Display message. |
+| `data` | `Map<String, dynamic>` | Full data payload from backend. |
+| `actionUrl` | `String?` | Optional deep link URL. |
+| `createdAt` | `DateTime` | When notification was created. |
+| `readAt` | `DateTime?` | When notification was read (`null` if unread). |
+| `isRead` | `bool` (getter) | `true` if `readAt != null`. |
+
+Factory: `DatabaseNotification.fromMap(map)` — parses Laravel notification response shape.
+
+### PaginatedNotifications
+
+Wraps the Laravel paginated response (`data` + `meta` keys).
+
+| Property | Type | Description |
+|:---------|:-----|:------------|
+| `data` | `List<DatabaseNotification>` | Notifications for current page. |
+| `currentPage` | `int` | Current page number. |
+| `lastPage` | `int` | Last available page number. |
+| `perPage` | `int` | Items per page. |
+| `total` | `int` | Total notification count. |
+| `hasMorePages` | `bool` | Whether more pages are available. |
+| `isEmpty` | `bool` | Whether the result has no items. |
+
+### PushMessage
+
+Fluent builder for push notification content.
+
+```dart
+PushMessage()
+  .heading('Alert Title')
+  .content('Alert body text')
+  .data({'key': 'value'})
+  .url('/deep/link');
+```
+
+| Method | Parameters | Description |
+|:-------|:-----------|:------------|
+| `heading(value)` | `String` | Set notification title. Returns `this`. |
+| `content(value)` | `String` | Set notification body. Returns `this`. |
+| `data(value)` | `Map<String, dynamic>` | Set full data payload. Returns `this`. |
+| `addData(key, value)` | `String key`, `dynamic value` | Add single key to data payload. Returns `this`. |
+| `url(value)` | `String` | Set deep link URL. Returns `this`. |
+| `toMap()` | — | Convert to `Map<String, dynamic>` (excludes null fields). |
+
+### NotificationPreference
+
+User-level channel preferences. Use `isEnabled(type, channel)` to gate channel delivery.
+
+| Property | Type | Description |
+|:---------|:-----|:------------|
+| `pushEnabled` | `bool` | Global push toggle. Default `true`. |
+| `emailEnabled` | `bool` | Global email toggle. Default `true`. |
+| `inAppEnabled` | `bool` | Global in-app toggle. Default `true`. |
+| `typePreferences` | `Map<String, ChannelPreference>` | Per-type overrides keyed by notification type string. |
+
+`isEnabled(notificationType, channel)` returns `false` if either the global toggle or the type-specific toggle is disabled. Returns `true` by default if no type-specific preference exists.
+
+## Configuration
+
+Add to `lib/config/notifications.dart` and register via `configFactories`:
+
+```dart
+'notifications': {
+  'push': {
+    'driver': env('PUSH_DRIVER', 'onesignal'),      // 'onesignal' is the only built-in driver
+    'app_id': env('ONESIGNAL_APP_ID', ''),           // OneSignal app ID
+    'safari_web_id': env('ONESIGNAL_SAFARI_ID', ''), // Safari web push ID (web only)
+    'notify_button_enabled': false,                  // Show OneSignal bell widget (web)
+  },
+  'database': {
+    'enabled': true,
+    'polling_interval': 30,   // Seconds between background fetches
+  },
+  'mail': {
+    'enabled': false,         // Mail channel requires backend handler
+  },
+  'soft_prompt': {
+    // Soft prompt dialog configuration (see PushPromptDialog)
+  },
+},
+```
+
+## Service Provider Setup
+
+Register `NotificationServiceProvider` in `config/app.dart`. It is NOT auto-registered.
+
+```dart
+// config/app.dart
+'providers': [
+  // ...existing providers...
+  (app) => NotificationServiceProvider(app),
+],
+```
+
+`NotificationServiceProvider.register()` binds `NotificationManager` singleton. `boot()` reads config, creates the `OneSignalDriver`, and initializes it.
+
+## Usage Patterns
+
+### Basic Setup & Lifecycle
+
+```dart
+import 'package:magic_notifications/magic_notifications.dart';
+
+// After user login
+await Notify.initializePush(user.id.toString());
+Notify.startPolling();
+
+// On app background (e.g., in AppLifecycleListener)
+Notify.pausePolling();
+
+// On app foreground
+Notify.resumePolling();
+
+// On logout
+await Notify.logoutPush();
+Notify.stopPolling();
+await Auth.logout();
+```
+
+### Display Notifications in UI
+
+```dart
+StreamBuilder<List<DatabaseNotification>>(
+  stream: Notify.notifications(),
+  builder: (context, snapshot) {
+    final notifications = snapshot.data ?? [];
+    final unread = notifications.where((n) => !n.isRead).length;
+
+    return Badge(
+      count: unread,
+      child: Icon(Icons.notifications),
+    );
+  },
+)
+```
+
+### Paginated Notification List
+
+```dart
+final result = await Notify.fetchPaginatedNotifications(page: 1, perPage: 20);
+
+for (final notification in result.data) {
+  print('${notification.title}: ${notification.body}');
+}
+
+if (result.hasMorePages) {
+  final nextPage = await Notify.fetchPaginatedNotifications(
+    page: result.currentPage + 1,
+    perPage: 20,
+  );
+}
+```
+
+### Listening to Push Events
+
+```dart
+// In a controller or service provider boot()
+Notify.manager.pushDriver.onNotificationClicked.listen((event) {
+  final url = event.data['url'] as String?;
+  if (url != null) {
+    Route.to(url);
+  }
+});
+```
+
+### Custom Channel Registration
+
+```dart
+// In NotificationServiceProvider.boot() or AppServiceProvider.boot()
+Notify.manager.registerChannel(MyCustomChannel());
+```
+
+## Gotchas
+
+| Mistake | Fix |
+|:--------|:----|
+| `NotificationServiceProvider` not registered | It is NOT auto-registered. Add `(app) => NotificationServiceProvider(app)` to `config/app.dart`. |
+| `Notify.initializePush()` throws `PUSH_DRIVER_NOT_CONFIGURED` | `NotificationServiceProvider` must be registered and `notifications.push.app_id` must be non-empty in config. |
+| `Notify.manager.pushDriver` accessed before push init | Throws `NotificationException`. Guard with `try/catch` or ensure provider is registered. |
+| Push login called before permission granted | `initializePush()` silently defers the external ID association. It will not throw, but the device won't be linked until a subscription is active. |
+| Polling not stopped on logout | Always call `Notify.stopPolling()` on logout — the timer holds a reference to `NotificationManager` and will keep fetching. |
+| `notifications()` stream never emits | The stream emits current cache immediately to each new listener. If the cache is empty, subscribe then call `fetchNotifications()` to trigger the first emission. |
+| `markAsRead()` / `deleteNotification()` reverts | These are optimistic — if the backend call fails, local state is reverted. UI will flash back to previous state. |
+| `via()` returns unknown channel name | `NotificationManager.send()` logs a warning but does not throw. The notification is silently skipped for that channel. |
+| `toDatabase()` returns `null` for `'database'` channel | `DatabaseChannel` skips delivery without error. Ensure `toDatabase()` returns a map with `title` and `body` keys. |
+| `PushNotSupportedException` on unsupported platform | Check `Notify.manager.pushDriver.isSupported` before calling push methods. |

--- a/skills/magic-framework/references/plugin-social-auth.md
+++ b/skills/magic-framework/references/plugin-social-auth.md
@@ -1,0 +1,351 @@
+# magic_social_auth Plugin
+
+Laravel Socialite-style social authentication for Magic Framework — Google, Microsoft, and GitHub out of the box with a pluggable driver system.
+
+## Registration
+
+`SocialAuthServiceProvider` is NOT included in Magic's default providers. Add it explicitly:
+
+```dart
+// config/app.dart
+'providers': [
+  AppServiceProvider,   // Must register Auth user factory first
+  AuthServiceProvider,
+  SocialAuthServiceProvider,  // Add this
+  // ...
+],
+```
+
+```dart
+import 'package:magic_social_auth/magic_social_auth.dart';
+```
+
+## SocialAuth Facade
+
+Static access to the social authentication system.
+
+| Method | Return | Description |
+|:-------|:-------|:------------|
+| `SocialAuth.driver(name)` | `SocialDriver` | Get a driver by provider name. Cached after first resolve. |
+| `SocialAuth.supports(name)` | `bool` | Check if provider supports the current platform. Returns `false` on any error. |
+| `SocialAuth.signOut()` | `Future<void>` | Sign out all cached drivers and clear the driver cache. |
+| `SocialAuth.manager` | `SocialAuthManager` | Direct access to the manager instance. |
+
+```dart
+// Authenticate with a provider
+await SocialAuth.driver('google').authenticate();
+
+// Guard against unsupported platforms before showing button
+if (SocialAuth.supports('github')) {
+  await SocialAuth.driver('github').authenticate();
+}
+
+// Sign out (clears Google native session, forgets all drivers)
+await SocialAuth.signOut();
+```
+
+## SocialAuthManager
+
+Singleton manager — use `SocialAuth.manager` to access it.
+
+| Method | Description |
+|:-------|:------------|
+| `driver(name)` | Resolve driver by name (cached). Throws `ProviderNotConfiguredException` if disabled. |
+| `extend(name, factory)` | Register a custom driver factory `(Map<String, dynamic> config) => SocialDriver`. Clears cached instance. |
+| `setHandler(handler)` | Replace the default `HttpSocialAuthHandler` with a custom `SocialAuthHandler`. |
+| `handleAuth(token)` | Called internally by drivers. Routes token to the registered handler. |
+| `createUser(data)` | Delegates to `Auth.manager.createUser(data)` — uses the app's registered user factory. |
+| `registerProviderDefaults(provider, defaults)` | Register `SocialProviderDefaults` for a custom provider so `SocialAuthButtons` can render it. |
+| `forgetDrivers()` | Clear all cached driver instances (use in test `tearDown`). |
+| `signOut()` | Call `signOut()` on every cached driver, then clear the cache. |
+
+## Built-in Drivers
+
+| Driver | Config key | Platforms | Flow |
+|:-------|:-----------|:----------|:-----|
+| `GoogleDriver` | `google` | iOS, Android, Web | Native SDK (mobile) / authorization popup (web) |
+| `MicrosoftDriver` | `microsoft` | iOS, Android, Web, macOS, Windows | OAuth PKCE via `flutter_web_auth_2` |
+| `GithubDriver` | `github` | iOS, Android, Web, macOS, Windows, Linux | OAuth browser flow via `flutter_web_auth_2` |
+
+### Token flows
+
+- **Google (mobile)**: Returns `accessToken` + `idToken` + profile fields. Backend verifies ID token.
+- **Google (web)**: Returns `accessToken` only — backend must call Google's userinfo API.
+- **Microsoft / GitHub**: Returns empty `accessToken` + `authorizationCode`. Backend must exchange the code for a token. Check `token.isCodeExchange` to detect this flow.
+
+## Contracts
+
+### SocialDriver (abstract)
+
+```dart
+abstract class SocialDriver {
+  SocialDriver(this.config);
+
+  final Map<String, dynamic> config;
+
+  String get name;
+  Set<SocialPlatform> get supportedPlatforms;
+
+  // Check current platform. Pass explicit platform to override detection.
+  bool supportsPlatform([SocialPlatform? platform]);
+
+  // Step 1: open native SDK / browser, return token.
+  Future<SocialToken> getToken();
+
+  // Step 2: calls getToken() then manager.handleAuth(token). Override rarely.
+  Future<void> authenticate();
+
+  // No-op by default. Override in drivers with native sign-out (Google).
+  Future<void> signOut();
+}
+```
+
+### SocialAuthHandler (abstract)
+
+Called after `getToken()` succeeds. The default implementation (`HttpSocialAuthHandler`) POSTs the token to the backend and calls `Auth.login()`.
+
+```dart
+abstract class SocialAuthHandler {
+  Future<void> handle(SocialToken token);
+}
+```
+
+**Default: `HttpSocialAuthHandler`**
+
+1. Reads `social_auth.endpoint` from config (default `'/auth/social/{provider}'`).
+2. Replaces `{provider}` with `token.provider` and sends `POST` with `token.toMap()`.
+3. Expects `{"data": {"token": "...", "user": {...}}}` from the backend.
+4. Calls `Auth.login({'token': authToken}, user)`.
+
+## Models
+
+### SocialToken
+
+Returned by `driver.getToken()` and passed to `handleAuth()`.
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `provider` | `String` | Driver name: `'google'`, `'microsoft'`, `'github'` |
+| `accessToken` | `String` | OAuth access token. Empty string for code-exchange flows. |
+| `authorizationCode` | `String?` | OAuth authorization code (Microsoft, GitHub). |
+| `idToken` | `String?` | JWT ID token (Google mobile, Microsoft). |
+| `email` | `String?` | User's email — may be null on web flows. |
+| `name` | `String?` | User's display name — may be null on web flows. |
+| `avatarUrl` | `String?` | User's avatar URL — may be null on web flows. |
+| `extra` | `Map<String, dynamic>?` | Provider-specific extra data. |
+| `isCodeExchange` | `bool` | Getter: `true` when `authorizationCode != null`. |
+
+```dart
+// toMap() is what the handler POSTs to the backend
+token.toMap();
+// {
+//   'provider': 'github',
+//   'access_token': '',
+//   'authorization_code': 'ghu_xxx',  // only when present
+//   'id_token': '...',                 // only when present
+//   'email': '...',                    // only when present
+//   ...
+// }
+```
+
+### SocialPlatform
+
+```dart
+enum SocialPlatform { ios, android, web, macos, windows, linux }
+
+// Current platform (auto-detected)
+SocialPlatformExtension.current  // → SocialPlatform.ios, etc.
+
+platform.isMobile   // ios or android
+platform.isDesktop  // macos, windows, or linux
+```
+
+## Configuration
+
+Add to your `config/` directory and register the config factory:
+
+```dart
+// lib/config/social_auth.dart
+const Map<String, dynamic> defaultSocialAuthConfig = {
+  'social_auth': {
+    // Backend endpoint template. {provider} is replaced at runtime.
+    'endpoint': '/auth/social/{provider}',
+
+    'providers': {
+      'google': {
+        'enabled': true,
+        'client_id': null,           // iOS/Android client ID from Google Console
+        'server_client_id': null,    // Web/server client ID (mobile only)
+        'scopes': ['email', 'profile'],
+        'label': 'Google',           // Override button label
+        'icon_svg': null,            // Override button icon SVG
+        'order': 1,                  // Button render order
+      },
+      'microsoft': {
+        'enabled': true,
+        'client_id': null,           // Azure App Registration client ID
+        'tenant': 'common',          // 'common', 'organizations', or tenant GUID
+        'scopes': ['openid', 'profile', 'email'],
+        'callback_scheme': 'myapp',  // Custom URL scheme for mobile callback
+        'web_callback_url': null,    // Full callback URL for web
+        'label': 'Microsoft',
+        'order': 2,
+      },
+      'github': {
+        'enabled': true,
+        'client_id': null,           // GitHub OAuth App client ID
+        'scopes': ['read:user', 'user:email'],
+        'callback_scheme': 'myapp',  // Custom URL scheme for mobile callback
+        'web_callback_url': null,    // Full callback URL for web
+        'label': 'GitHub',
+        'order': 3,
+      },
+    },
+  },
+};
+```
+
+Register via `configFactories` if any values need `Env.get()`:
+
+```dart
+// In Magic.init() call
+configFactories: [
+  () => {
+    'social_auth': {
+      'endpoint': '/auth/social/{provider}',
+      'providers': {
+        'google': {
+          'enabled': true,
+          'client_id': Env.get('GOOGLE_CLIENT_ID'),
+          'server_client_id': Env.get('GOOGLE_SERVER_CLIENT_ID'),
+        },
+        'github': {
+          'enabled': true,
+          'client_id': Env.get('GITHUB_CLIENT_ID'),
+          'callback_scheme': Env.get('APP_SCHEME', fallback: 'myapp'),
+        },
+      },
+    },
+  },
+],
+```
+
+## SocialAuthButtons Widget
+
+Config-driven buttons — reads `social_auth.providers`, filters by `enabled` flag and platform support, renders in `order`.
+
+```dart
+SocialAuthButtons(
+  onAuthenticate: (provider) async {
+    setState(() => _loadingProvider = provider);
+    try {
+      await SocialAuth.driver(provider).authenticate();
+      Route.to('/dashboard');
+    } on SocialAuthCancelledException {
+      // User cancelled — do nothing
+    } on SocialAuthException catch (e) {
+      MagicFeedback.error(e.message);
+    } finally {
+      setState(() => _loadingProvider = null);
+    }
+  },
+  loadingProvider: _loadingProvider,  // Shows spinner on tapped button, disables others
+  mode: SocialAuthMode.signIn,        // Or SocialAuthMode.signUp
+)
+```
+
+| Prop | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| `onAuthenticate` | `Future<void> Function(String provider)` | required | Callback with the provider name. |
+| `loadingProvider` | `String?` | `null` | Provider currently loading. Pass empty string to disable all buttons. |
+| `mode` | `SocialAuthMode` | `signIn` | Changes button label text. Uses `trans('auth.sign_in_with'/'auth.sign_up_with')`. |
+| `className` | `String?` | `null` | Override outer container className. |
+| `buttonClassName` | `String?` | `null` | Override individual button className. |
+| `labelBuilder` | `String Function(String provider, SocialAuthMode mode)?` | `null` | Custom label builder. Overrides `trans()` lookup. |
+
+Label translation keys required:
+- `auth.sign_in_with` with `:provider` placeholder
+- `auth.sign_up_with` with `:provider` placeholder
+
+## Custom Driver
+
+```dart
+// 1. Implement SocialDriver
+class AppleDriver extends SocialDriver {
+  AppleDriver(super.config);
+
+  @override
+  String get name => 'apple';
+
+  @override
+  Set<SocialPlatform> get supportedPlatforms => {
+    SocialPlatform.ios,
+    SocialPlatform.macos,
+  };
+
+  @override
+  Future<SocialToken> getToken() async {
+    // Implement Apple Sign In
+    // ...
+    return SocialToken(
+      provider: name,
+      accessToken: credential.identityToken ?? '',
+      idToken: credential.identityToken,
+      email: credential.email,
+      name: credential.fullName?.givenName,
+    );
+  }
+}
+
+// 2. Register in a ServiceProvider.boot()
+SocialAuth.manager.extend('apple', (config) => AppleDriver(config));
+
+// 3. Register UI metadata so SocialAuthButtons renders it
+SocialAuth.manager.registerProviderDefaults('apple', const SocialProviderDefaults(
+  label: 'Apple',
+  iconSvg: '<svg>...</svg>',
+  order: 0,   // Render first
+));
+```
+
+## Custom Handler (e.g., Firebase)
+
+```dart
+class FirebaseAuthHandler implements SocialAuthHandler {
+  @override
+  Future<void> handle(SocialToken token) async {
+    final credential = GoogleAuthProvider.credential(
+      idToken: token.idToken,
+      accessToken: token.accessToken.isNotEmpty ? token.accessToken : null,
+    );
+    await FirebaseAuth.instance.signInWithCredential(credential);
+    // Optionally call Auth.login() to sync with Magic's auth state
+  }
+}
+
+// Register before first authenticate() call
+SocialAuth.manager.setHandler(FirebaseAuthHandler());
+```
+
+## Exceptions
+
+| Exception | When thrown |
+|:----------|:------------|
+| `SocialAuthException(message, {code})` | Base exception for all auth failures. |
+| `SocialAuthCancelledException` | User cancelled the auth flow (dismisses sheet/browser). |
+| `UnsupportedPlatformException(message)` | Driver called on an unsupported platform. |
+| `ProviderNotConfiguredException(provider)` | Provider's `enabled: false` in config, or driver name not recognized. |
+
+## Gotchas
+
+| Mistake | Fix |
+|:--------|:----|
+| `SocialAuthServiceProvider` not registered | Add it manually to `config/app.dart` providers — it is NOT auto-registered. |
+| `Auth.manager.setUserFactory()` not called | `SocialAuthManager.createUser()` delegates to `Auth.manager` — the factory must be registered before `authenticate()` completes. |
+| `SocialAuthButtons` renders nothing | Check that at least one provider has `enabled: true` AND supports the current platform. |
+| `trans('auth.sign_in_with')` key missing | Add `"sign_in_with": "Sign in with :provider"` and `"sign_up_with": "Sign up with :provider"` to your `auth` translation namespace. |
+| Microsoft/GitHub `accessToken` is empty | Both drivers use code exchange. Check `token.isCodeExchange` — backend must exchange `authorizationCode` for a token. |
+| Google web sends no email/name | Web authorization popup returns only `accessToken`. Backend must call Google's userinfo API to get profile data. |
+| Custom driver not shown in `SocialAuthButtons` | Call `registerProviderDefaults()` in addition to `extend()` — the widget won't render providers without UI metadata. |
+| `SocialAuth.manager.forgetDrivers()` in tests | Call this in `tearDown()` alongside `MagicApp.reset()` + `Magic.flush()` to clear cached driver instances. |
+| `callback_scheme` mismatch | The scheme in config must exactly match the custom URL scheme registered in your app's native manifest. |

--- a/skills/magic-framework/references/plugin-starter.md
+++ b/skills/magic-framework/references/plugin-starter.md
@@ -1,0 +1,315 @@
+# magic_starter Plugin
+
+Full-stack Flutter starter kit for Magic Framework — pre-built auth flows, team management, profile settings, notification UI, and responsive app/guest layouts with an opt-in feature flag system.
+
+**Version:** 0.0.1-alpha.1 · **Requires:** `magic ^1.0.0-alpha.3`, `magic_notifications ^0.0.1-alpha.1`
+
+## Installation & Setup
+
+```bash
+# Scaffold config, register provider, inject config into main.dart
+dart run magic_starter:install
+
+# Reconfigure features interactively
+dart run magic_starter:configure
+
+# Diagnose configuration issues
+dart run magic_starter:doctor
+
+# Publish config/assets for customization
+dart run magic_starter:publish
+
+# Remove plugin scaffolding
+dart run magic_starter:uninstall
+```
+
+Register the service provider in `lib/config/app.dart`:
+
+```dart
+'providers': [
+  AppServiceProvider,        // Must boot before MagicStarterServiceProvider
+  AuthServiceProvider,
+  (app) => MagicStarterServiceProvider(app),
+],
+```
+
+## MagicStarter Facade API
+
+Accessed via `package:magic_starter/magic_starter.dart`. All configuration calls should be made in a `ServiceProvider.boot()` method.
+
+### User Model
+
+| Method / Property | Signature | Description |
+|:------------------|:----------|:------------|
+| `useUserModel(factory)` | `void` | Register factory to hydrate your `User` model from API data. |
+| `createUser(data)` | `Authenticatable` | Instantiate a user model using the registered factory. |
+
+```dart
+MagicStarter.useUserModel((data) => User.fromMap(data));
+```
+
+### Teams
+
+| Method / Property | Signature | Description |
+|:------------------|:----------|:------------|
+| `useTeamResolver({currentTeam, allTeams, onSwitch})` | `void` | Register team accessor callbacks for the app layout. Required when `features.teams` is enabled. |
+| `teamResolver` | `MagicStarterTeamResolverConfig?` | Get registered config, or `null`. |
+| `hasTeamResolver` | `bool` | Whether a team resolver has been registered. |
+
+```dart
+MagicStarter.useTeamResolver(
+  currentTeam: () => Auth.user<User>()?.currentTeam?.toMagicStarterTeam(),
+  allTeams: () => Auth.user<User>()?.allTeams.map((t) => t.toMagicStarterTeam()).toList() ?? [],
+  onSwitch: (id) => MagicStarterTeamController.instance.switchTeam(id),
+);
+```
+
+### Navigation
+
+| Method / Property | Signature | Description |
+|:------------------|:----------|:------------|
+| `useNavigation({mainItems, systemItems, bottomItems, profileMenuItems})` | `void` | Register navigation items for the app layout. |
+| `navigationConfig` | `MagicStarterNavigationConfig?` | Get registered config, or `null`. |
+| `hasNavigation` | `bool` | Whether navigation has been registered. |
+
+```dart
+MagicStarter.useNavigation(
+  mainItems: [
+    MagicStarterNavItem(icon: Icons.dashboard, labelKey: 'nav.dashboard', path: '/'),
+    MagicStarterNavItem(icon: Icons.monitor_heart, labelKey: 'nav.monitors', path: '/monitors'),
+  ],
+  bottomItems: [
+    MagicStarterNavItem(icon: Icons.dashboard_outlined, activeIcon: Icons.dashboard, labelKey: 'nav.dashboard', path: '/'),
+  ],
+  profileMenuItems: [
+    MagicStarterNavItem(icon: Icons.notifications_outlined, labelKey: 'nav.notifications', path: '/notifications'),
+  ],
+);
+```
+
+`MagicStarterNavItem` fields: `icon` (required), `labelKey` (required, passed through `trans()`), `path` (required), `activeIcon` (optional).
+
+### Custom Behaviors
+
+| Method / Property | Signature | Description |
+|:------------------|:----------|:------------|
+| `useLogout(callback)` | `void` | Override the default logout handler in the app layout. |
+| `useHeader(builder)` | `void` | Replace the default app layout header. Builder receives `(context, isDesktop)`. |
+| `useSocialLogin(builder)` | `void` | Register custom social login buttons (requires `features.social_login`). Builder receives `(context, isLoading)`. |
+| `hasSocialLogin` | `bool` | Whether social login builder is registered. |
+| `socialLoginBuilder` | `SocialLoginBuilder?` | Get registered builder, or `null`. |
+| `useGuestAuthEntry(builder)` | `void` | Register custom widget for guest/anonymous login flows (requires `features.guest_auth`). |
+| `guestAuthEntryBuilder` | `Widget Function()?` | Get registered builder, or `null`. |
+| `useNewsletterLabel(label)` | `void` | Override the default newsletter checkbox label. |
+| `newsletterLabel` | `String?` | Get registered label, or `null`. |
+| `useLocaleOptions(locales)` | `void` | Register custom locale options for the language selector. Takes `Map<String, String>` of code → native name. |
+| `localeOptions` | `List<SelectOption<String>>` | Get locale options (auto-derived from `Lang.supportedLocales` if not overridden). |
+
+### Notifications
+
+| Method / Property | Signature | Description |
+|:------------------|:----------|:------------|
+| `useNotificationTypeMapper(mapper)` | `void` | Register a mapper to resolve notification types to icons and color classes. |
+| `notificationTypeMapper` | `MagicStarterNotificationTypeMapper?` | Get registered mapper, or `null` (views use built-in defaults). |
+
+```dart
+MagicStarter.useNotificationTypeMapper((type) => switch (type) {
+  'monitor_down' => (icon: Icons.error_outline, colorClass: 'text-red-500'),
+  'monitor_up' => (icon: Icons.check_circle_outline, colorClass: 'text-green-500'),
+  _ => (icon: Icons.info_outline, colorClass: 'text-blue-500'),
+});
+```
+
+Notification polling is handled automatically by the app layout. See `plugin-notifications.md` for the `Notify` facade API.
+
+### Access
+
+| Property | Type | Description |
+|:---------|:-----|:------------|
+| `manager` | `MagicStarterManager` | Direct manager access via IoC. |
+| `view` | `MagicStarterViewRegistry` | View registry for overriding built-in screens. |
+| `isReady` | `bool` | `false` when teams are enabled but no team resolver is configured. |
+
+## Configuration
+
+Copy from `lib/config/magic_starter.dart` into your app config:
+
+```dart
+'magic_starter': {
+  'features': {
+    'teams': false,
+    'profile_photos': false,
+    'registration': true,
+    'two_factor': false,
+    'sessions': false,
+    'guest_auth': false,
+    'phone_otp': false,
+    'newsletter': false,
+    'email_verification': false,
+    'extended_profile': true,
+    'social_login': true,
+    'notifications': true,
+    'timezones': false,
+  },
+  'auth': {
+    'email': true,    // Email-based login/register
+    'phone': false,   // Phone-based login/register (can enable both)
+  },
+  'defaults': {
+    'locale': 'en',
+    'timezone': 'UTC',
+  },
+  'supported_locales': ['en', 'tr'],
+  'routes': {
+    'home': '/',
+    'login': '/auth/login',
+    'auth_prefix': '/auth',
+    'teams_prefix': '/teams',
+    'profile_prefix': '/settings',
+    'notifications_prefix': '/notifications',
+  },
+  'legal': {
+    'terms_url': null,    // Shows ToS link on register page when set
+    'privacy_url': null,  // Shows Privacy link on register page when set
+  },
+},
+```
+
+All 13 features default to `false` in code. The template above has some enabled as a reasonable starting point — adjust per your backend configuration.
+
+## View Registry
+
+Override any pre-built screen by registering a custom builder under its string key. Call `MagicStarter.view.register()` in a service provider `boot()`.
+
+```dart
+// Override a single screen
+MagicStarter.view.register('auth.login', () => CustomLoginView());
+
+// Override a layout shell
+MagicStarter.view.registerLayout('layout.app', (child) => CustomAppLayout(child: child));
+```
+
+### Built-in View Keys
+
+| Key | Condition | Default Widget |
+|:----|:----------|:---------------|
+| `auth.login` | always | `MagicStarterLoginView` |
+| `auth.register` | always | `MagicStarterRegisterView` |
+| `auth.forgot_password` | always | `MagicStarterForgotPasswordView` |
+| `auth.reset_password` | always | `MagicStarterResetPasswordView` |
+| `auth.two_factor_challenge` | `features.two_factor` | `MagicStarterTwoFactorChallengeView` |
+| `auth.otp_verify` | `features.phone_otp` | `MagicStarterOtpVerifyView` |
+| `profile.settings` | always | `MagicStarterProfileSettingsView` |
+| `teams.create` | `features.teams` | `MagicStarterTeamCreateView` |
+| `teams.settings` | `features.teams` | `MagicStarterTeamSettingsView` |
+| `teams.invitation_accept` | `features.teams` | `MagicStarterTeamInvitationAcceptView` |
+| `notifications.list` | `features.notifications` | `MagicStarterNotificationsListView` |
+| `notifications.preferences` | `features.notifications` | `MagicStarterNotificationPreferencesView` |
+| `layout.guest` | always | `MagicStarterGuestLayout` |
+| `layout.app` | always | `MagicStarterAppLayout` |
+
+Registry methods: `register(key, builder)`, `registerLayout(key, layoutBuilder)`, `has(key)`, `hasLayout(key)`, `make(key)`, `makeLayout(key, child: child)`. `make()` throws `StateError` for unregistered keys.
+
+## Controllers
+
+All controllers use the `Magic.findOrPut(ControllerClass.new)` singleton pattern. Access via `.instance`.
+
+| Controller | Singleton | Responsibilities |
+|:-----------|:----------|:----------------|
+| `MagicStarterAuthController` | `.instance` | Login, register, forgot/reset password, 2FA challenge, logout |
+| `MagicStarterGuestAuthController` | `.instance` | Guest/anonymous login flows |
+| `MagicStarterOtpController` | `.instance` | Phone OTP verification |
+| `MagicStarterProfileController` | `.instance` | Profile info, password change, sessions, account deletion |
+| `MagicStarterTeamController` | `.instance` | Team create, settings, member management, team switching |
+| `MagicStarterNotificationController` | `.instance` | Notification preferences matrix, per-channel toggles |
+| `MagicStarterNewsletterController` | `.instance` | Newsletter subscription management |
+
+### Auth Controller Key Methods
+
+```dart
+// Login — phone takes precedence in dual-identity mode
+await MagicStarterAuthController.instance.doLogin(
+  email: 'user@example.com',
+  password: 'secret',
+  rememberMe: true,
+);
+
+// Register — auto-logins if backend returns token+user
+await MagicStarterAuthController.instance.doRegister(
+  name: 'Alice',
+  email: 'alice@example.com',
+  password: 'secret',
+  passwordConfirmation: 'secret',
+  subscribeNewsletter: true,
+);
+
+// 2FA — provide code OR recoveryCode, never both
+await MagicStarterAuthController.instance.doTwoFactorChallenge(
+  twoFactorToken: tokenFromLoginResponse,
+  code: '123456',
+);
+
+// Logout — stops Notify polling, calls Auth.logout(), redirects
+await MagicStarterAuthController.instance.logout();
+```
+
+### Notification Controller Key Methods
+
+```dart
+// Fetch preference matrix from GET /notification-preferences
+await MagicStarterNotificationController.instance.fetchPreferences();
+
+// Toggle a channel preference (optimistic update, rolls back on failure)
+await MagicStarterNotificationController.instance.updateTypePreference(
+  'monitor_down',  // notification type key
+  'email',         // channel name
+  true,            // enabled
+);
+
+// Reactive matrix access
+ValueListenableBuilder(
+  valueListenable: MagicStarterNotificationController.instance.matrixNotifier,
+  builder: (context, matrix, _) { /* ... */ },
+);
+```
+
+Matrix structure from backend: `{ "type_key": { "label": "...", "channels": { "channel": { "enabled": bool, "locked": bool } } } }`
+
+## Layouts & Notification Integration
+
+The app layout (`layout.app`) auto-manages notification polling:
+
+- `initState` → calls `Notify.startPolling()` when `features.notifications` is enabled
+- `dispose` → calls `Notify.stopPolling()` as a safety net
+- `AuthRestored` event → triggers `Magic.reload()` to refresh team-scoped data
+
+For the `Notify` facade API (polling interval, badge counts, push token registration, `logoutPush`), see `plugin-notifications.md`.
+
+## Gate Abilities
+
+`MagicStarterServiceProvider` registers 9 abilities during `boot()`. All grant access when `user.is_guest != true`. Override any by calling `Gate.define()` with the same key after the provider boots.
+
+| Ability | Controls |
+|:--------|:---------|
+| `starter.update-profile-photo` | Profile photo upload/remove section |
+| `starter.update-email` | Email field in profile information |
+| `starter.update-phone` | Phone field in extended profile |
+| `starter.update-password` | Password change section |
+| `starter.verify-email` | Email verification banner |
+| `starter.manage-two-factor` | Two-factor authentication section |
+| `starter.manage-newsletter` | Newsletter preferences section |
+| `starter.logout-sessions` | Session revoke buttons |
+| `starter.delete-account` | Account deletion section |
+
+## Gotchas
+
+| Mistake | Fix |
+|:--------|:----|
+| `features.teams` enabled but no `useTeamResolver()` call | `MagicStarter.isReady` returns `false`; a warning is logged at boot. Call `useTeamResolver()` in `AppServiceProvider.boot()`. |
+| `useUserModel()` not called | Starter falls back to `MagicStarterAuthUser` — your typed `User` model won't be hydrated. Always register before `MagicStarterServiceProvider` boots. |
+| View key not registered | `MagicStarter.view.make(key)` throws `StateError`. Conditional views (`two_factor`, `phone_otp`, notifications) are only registered when their feature flag is `true`. |
+| Calling `useTeamResolver()` / `useNavigation()` after `Magic.init()` | These calls are safe at any time, but the app layout reads the config at mount — call before the first navigation. |
+| `features.social_login` enabled but no `useSocialLogin()` builder | The feature flag gates the UI section; without a builder, the social login area renders nothing. |
+| Custom logout without stopping Notify polling | If you override `useLogout()`, call `Notify.logoutPush()` and `Notify.stopPolling()` manually. See `plugin-notifications.md`. |
+| `MagicStarterServiceProvider` registered before `AppServiceProvider` | `useUserModel()` in `AppServiceProvider.boot()` runs after the starter's `register()` but before its `boot()`. Order: `AppServiceProvider` first, then `MagicStarterServiceProvider`. |
+| `two_factor` view key missing at runtime | The view is only registered in `registerDefaultViews()` when `MagicStarterConfig.hasTwoFactorFeatures()` is `true` at boot time. Feature flags must be set before `Magic.init()`. |


### PR DESCRIPTION
## Summary
- Add 4 new reference docs for official ecosystem plugins: `magic_deeplink`, `magic_notifications`, `magic_social_auth`, `magic_starter`
- Extend SKILL.md with plugin trigger keywords in description, new Section 9.5 (Ecosystem Plugins) with suggestion logic, and 4 new Reference Index entries
- Token-efficient: SKILL.md grew only ~25 lines; detailed content lives in on-demand reference files

## Test plan
- [ ] Verify all 4 reference files render correctly on GitHub
- [ ] Verify SKILL.md Section 9.5 plugin suggestion table is complete
- [ ] Verify plugin-starter.md cross-references plugin-notifications.md (no duplication)
- [ ] Verify no platform-specific setup instructions leaked into reference files