### PR TITLE
chore(release): 1.0.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.0-alpha.5] - 2026-03-29
+
 ### 🐛 Bug Fixes
 - **Route Back Navigation**: `MagicRoute.back()` now works after `go()`-based navigation (cross-shell). Maintains lightweight history stack with automatic fallback. Optional `fallback` parameter for explicit control. (#11)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Laravel-inspired Flutter framework with Facades, Eloquent ORM, Service Providers, and IoC Container.
 
-**Version:** 1.0.0-alpha.4 · **Dart:** >=3.11.0 · **Flutter:** >=3.41.0
+**Version:** 1.0.0-alpha.5 · **Dart:** >=3.11.0 · **Flutter:** >=3.41.0
 
 ## Commands
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic
 description: "A Laravel-inspired Flutter framework with Eloquent ORM, routing, and MVC architecture."
-version: 1.0.0-alpha.4
+version: 1.0.0-alpha.5
 homepage: https://magic.fluttersdk.com
 repository: https://github.com/fluttersdk/magic
 issue_tracker: https://github.com/fluttersdk/magic/issues


### PR DESCRIPTION
## Summary

- Version bump to `1.0.0-alpha.5`
- Moves `[Unreleased]` changelog content to `[1.0.0-alpha.5]`

## Changelog

### Bug Fixes
- **Route Back Navigation**: `MagicRoute.back()` now works after `go()`-based navigation (cross-shell). Maintains lightweight history stack with automatic fallback. Optional `fallback` parameter for explicit control. (#11)

## Test plan

- [x] 463 tests pass
- [x] `dart analyze` — zero issues
- [x] `dart format` — zero changes
- [x] `dart pub publish --dry-run` — clean