### PR TITLE
chore: add GitHub Copilot configuration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,57 @@
+# Magic Framework
+
+Laravel-inspired Flutter framework with Facades, Eloquent ORM, Service Providers, and IoC Container.
+
+**Dart:** >=3.11.0 | **Flutter:** >=3.41.0
+
+## Architecture
+
+**Pattern**: Service Provider + IoC Container + Facade (Laravel-inspired)
+
+```
+lib/
+├── magic.dart              # Barrel export (public API)
+├── config/                 # Default configs
+└── src/
+    ├── foundation/         # MagicApp (IoC), Magic (bootstrap), ConfigRepository, Env
+    ├── facades/            # 16 facades: Auth, Cache, Config, Crypt, DB, Event, Gate, Http, Lang, Launch, Log, Pick, Route, Schema, Storage, Vault
+    ├── auth/               # AuthManager, guards, events
+    ├── cache/              # CacheManager, drivers (memory, file)
+    ├── database/           # Eloquent ORM, QueryBuilder, migrations, seeders, factories
+    ├── http/               # MagicController, middleware pipeline, Kernel
+    ├── concerns/           # ValidatesRequests mixin (import from here, not http/)
+    ├── localization/       # Translator (JSON loaders)
+    ├── routing/            # MagicRouter (GoRouter wrapper)
+    ├── validation/         # Rules-based validator
+    └── ui/                 # MagicView, MagicForm, MagicFeedback
+```
+
+**Lifecycle:** `Magic.init()` -> `Env.load()` -> configFactories -> providers `register()` -> providers `boot()` -> router pre-build -> app ready
+
+**Resolution:** Facades use static singletons or container `Magic.make<T>(key)`
+
+## Key Conventions
+
+- Strict types -- every param, return, property typed
+- Multi-line + trailing commas everywhere, even with 2 items
+- Thin controllers, fat services -- no business logic in controllers
+- Contract-first: abstract class defines API shape
+- Two-phase bootstrap: `register()` binds, `boot()` configures
+- TDD required: failing test first, then implement, then refactor
+- Zero linter warnings (`dart analyze`), zero test failures (`flutter test`)
+- Import order: dart/flutter stdlib -> third-party -> `package:magic/magic.dart` -> relative
+
+## Key Gotchas
+
+| Mistake | Fix |
+|---------|-----|
+| Facade call before `Magic.init()` | Always `await Magic.init()` in `main()` first |
+| Missing `Auth.manager.setUserFactory()` | Must call in boot phase |
+| Forgetting test reset | `MagicApp.reset()` + `Magic.flush()` in every `setUp()` |
+| `EncryptionServiceProvider` / `LaunchServiceProvider` | NOT auto-registered -- add explicitly |
+| `ValidatesRequests` import | Lives in `concerns/`, not `http/` |
+| `Event.register()` takes factories | `List<Listener Function()>`, not listener instances |
+
+## Post-Change Checklist
+
+After ANY source code change: update CHANGELOG.md, doc/, README.md (if applicable), skills/magic-framework/, example/.

--- a/.github/instructions/auth.instructions.md
+++ b/.github/instructions/auth.instructions.md
@@ -1,0 +1,19 @@
+---
+name: 'Auth Conventions'
+description: 'Authentication domain -- guards, session restore, auth events'
+applyTo: 'lib/src/auth/**/*.dart'
+---
+
+# Auth Domain
+
+- `AuthManager` is singleton — accessed via `Auth` facade, never instantiate directly
+- **Critical**: `Auth.manager.setUserFactory((data) => User.fromMap(data))` MUST be called in boot phase — session restore fails without it
+- Built-in guards: `bearer`/`sanctum` (BearerTokenGuard, default), `basic` (BasicAuthGuard), `api_key` (ApiKeyGuard)
+- Guard contract (`Guard` abstract class): `login()`, `logout()`, `check()`, `user()`, `guest` (getter, not method), `restore()`
+- Custom guards: `Auth.manager.extend('firebase', (config) => FirebaseGuard())` — factory receives guard config map
+- Guard resolution: `Auth.guard()` returns default, `Auth.guard('api')` returns named. Cached after first resolution
+- Auth events: `Login`, `Logout`, `AuthRestored`, `AuthFailed` — register listeners via `EventDispatcher.instance.register()`
+- `Authenticatable` interface: models implementing auth must extend this. Provides `getAuthIdentifier()`, token methods
+- Config path: `auth.defaults.guard` for default guard name, `auth.guards.{name}` for guard-specific config
+- Token storage: guards use `Vault` (flutter_secure_storage) for token persistence. Vault must be available
+- `AuthServiceProvider` is auto-registered — binds AuthManager as singleton in register phase

--- a/.github/instructions/database.instructions.md
+++ b/.github/instructions/database.instructions.md
@@ -1,0 +1,24 @@
+---
+name: 'Database Conventions'
+description: 'Database domain -- Eloquent ORM, QueryBuilder, migrations, seeders'
+applyTo: 'lib/src/database/**/*.dart'
+---
+
+# Database Domain (Eloquent ORM)
+
+- `Model` is abstract — subclass with `table`, `resource` overrides. Add `HasTimestamps`, `InteractsWithPersistence` mixins as needed
+- Typed accessors: `String get name => getAttribute('name');` / `set name(String val) => setAttribute('name', val);`
+- Shorthand alias: `set('key', value)` calls `setAttribute()` internally
+- Mass assignment: use `fillable` (whitelist) OR `guarded` (blacklist `['*']` default), never both
+- Casts map: `'datetime'` → Carbon, `'json'` → Map, `'bool'` → bool, `'int'` → int, `'double'` → double
+- Relations: `Map<String, Model Function()> get relations => {'user': User.new}` — auto-cast from API responses
+- `exists` flag: set `true` after `fromMap()` for persisted models, controls insert vs update
+- `useLocal` / `useRemote` toggles: `useLocal` = SQLite persistence, `useRemote` = API persistence. Both can be true
+- QueryBuilder: fluent chaining — `.table('users').where('active', true).orderBy('name').get()`
+- QueryBuilder CRUD: `.insert(data)`, `.update(data)`, `.delete()`. Returns `Map<String, dynamic>` or `List<Map>`
+- Migrations: extend base Migration, implement `up()` / `down()` with `Schema` facade calls
+- Seeders: extend Seeder, implement `run()`. Use Factory for bulk test data
+- Connectors: platform-specific — `NativeConnector` (mobile), `WebConnector` (in-memory SQLite for web)
+- `DatabaseServiceProvider` auto-registers. Config key: `database.default` for driver name
+- `dirty` tracking: `isDirty`, `getDirty()`, `getOriginal()` — compares `_attributes` vs `_original`
+- Hidden/visible: `hidden` excludes from `toMap()`, `visible` restricts to whitelist. Hidden takes priority

--- a/.github/instructions/flutter.instructions.md
+++ b/.github/instructions/flutter.instructions.md
@@ -1,0 +1,21 @@
+---
+name: 'Flutter Conventions'
+description: 'Flutter/Dart stack -- imports, naming, platform splits, IoC'
+applyTo: 'lib/**/*.dart'
+---
+
+# Flutter / Dart Stack
+
+- Dart >=3.11.0, Flutter >=3.41.0 — use modern patterns (records, switch expressions, strict null safety)
+- Import order: dart/flutter stdlib → third-party packages → `package:magic/magic.dart` → relative imports (contracts before implementations)
+- Naming: `{Concept}` (facade), `{Concept}Manager` (service locator), `{Type}{Concept}Driver` (implementation), `{Concept}ServiceProvider` (bootstrap), `{Concept}Exception`, `{Purpose}Middleware`
+- Facade pattern: static getters proxy to `Magic.make<Manager>('key')`. Never instantiate managers directly
+- Contract-first: abstract class defines API shape. Implementations in subdirectory (guards/, drivers/, rules/)
+- Two-phase bootstrap: `register()` binds services (immediate), `boot()` configures them (deferred, `Future<void>`)
+- Platform splits: `_io.dart` / `_web.dart` suffix for platform-conditional code (SQLite, file I/O, secure storage)
+- Manager pattern: singleton manager resolves named drivers from config. `driver([String? name])` method with null-coalescing default
+- IoC binding: `app.singleton('key', () => Service())` for singletons, `app.bind('key', () => Service())` for factories
+- `ValidatesRequests` mixin: import from `lib/src/concerns/`, NOT from `lib/src/http/`
+- Event listeners are **factories**: `[() => Listener()]`, never instances
+- `MagicMiddleware.handle(void Function() next)` — async, call `next()` to proceed, skip to redirect
+- `analysis_options.yaml` uses `package:flutter_lints/flutter.yaml` — zero warnings required

--- a/.github/instructions/http.instructions.md
+++ b/.github/instructions/http.instructions.md
@@ -1,0 +1,22 @@
+---
+name: 'Http Conventions'
+description: 'HTTP domain -- controllers, middleware, state management'
+applyTo: 'lib/src/http/**/*.dart'
+---
+
+# HTTP Domain (Controllers & Middleware)
+
+- `MagicController extends ChangeNotifier` — lifecycle: `onInit()` → use → `onClose()` → `dispose()`
+- `@mustCallSuper` on both `onInit()` and `onClose()` — always call `super.onInit()` / `super.onClose()`
+- `MagicStateMixin<T>` on MagicController: reactive state via `rxState` (T?), `rxStatus` (RxStatus)
+- State helpers: `setLoading()`, `setSuccess(T data)`, `setError(String msg)`, `setEmpty()`
+- Status checks: `isLoading`, `isSuccess`, `isError`, `isEmpty` — boolean getters
+- `renderState(onSuccess, {onLoading, onError, onEmpty})` — declarative UI builder using AnimatedBuilder
+- `setState(T?, {RxStatus? status, bool notify = true})` — low-level; use helpers above
+- `refreshUI()` calls `notifyListeners()` with disposed guard — use this, not `notifyListeners()` directly
+- `SimpleMagicController` — auto-calls `onInit()` in constructor. No state mixin
+- `RxStatus` is const: `.loading()`, `.success()`, `.error(message)`, `.empty()`. Has `.type` (enum) and `.message`
+- `MagicMiddleware`: abstract with `Future<void> handle(void Function() next)`. Call `next()` to proceed, skip to redirect
+- `Kernel.register('name', () => MiddlewareInstance())` — factory registration, not instances
+- Middleware chain: registered names referenced in route `.middleware(['auth', 'admin'])` — resolved at navigation time
+- `Http` facade (network, not this module): RESTful methods + `MagicResponse` envelope. Different from controller layer

--- a/.github/instructions/routing.instructions.md
+++ b/.github/instructions/routing.instructions.md
@@ -1,0 +1,21 @@
+---
+name: 'Routing Conventions'
+description: 'Routing domain -- MagicRouter, route groups, layouts, navigation'
+applyTo: 'lib/src/routing/**/*.dart'
+---
+
+# Routing Domain
+
+- `MagicRouter` wraps GoRouter — singleton accessed via `MagicRouter.instance`
+- Route registration: `Route.get('/path', () => Widget())`, `Route.page('/path', () => Widget())` — `page()` preferred over deprecated `path()`
+- Route parameters: `Route.get('/users/:id', (id) => UserPage(id: id))` — params extracted from path
+- Route groups: `Route.group('/admin', middleware: ['auth'], routes: [...])` — nested routes with shared middleware/prefix
+- Layout wrapping: `Route.layout(() => AdminLayout(), routes: [...])` — shell route for persistent UI
+- Middleware binding: `.middleware(['auth', 'admin'])` — names must be registered in `Kernel`
+- Context-free navigation: `Route.to('/path')`, `Route.back()`, `Route.replace('/path')` — no BuildContext needed
+- `routerConfig` property: use with `MaterialApp.router(routerConfig: MagicRouter.instance.routerConfig)`
+- Router config only accessible AFTER `Magic.init()` completes — accessing before init throws
+- `RouteDefinition` — data class holding path, builder, middleware names, transition config
+- `LayoutDefinition` — shell route wrapper for persistent navigation (sidebar, bottom nav)
+- `RouteServiceProvider` registers routes in boot phase — recommended place for all route definitions
+- Custom transitions: `Route.get('/path', () => Page()).transition(TransitionType.fade)`

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,21 @@
+---
+name: 'Tests Conventions'
+description: 'Testing domain -- setUp, mocking, test structure, assertions'
+applyTo: 'test/**/*.dart'
+---
+
+# Testing Domain
+
+- `setUp()`: always `MagicApp.reset()` + `Magic.flush()` — clears IoC container and facade caches between tests
+- Mock via contract inheritance, never code generation (no mockito). Implement the abstract class directly
+- Test structure mirrors `lib/src/` exactly: `test/auth/`, `test/database/`, `test/http/`, etc.
+- Controller tests: `Magic.put<T>(controller)` to inject, then verify state transitions and `rxStatus` changes
+- Model tests: verify `getAttribute()`/`setAttribute()`, `fillable`/`guarded` mass assignment, `casts`, `toMap()`/`fromMap()`
+- Middleware tests: instantiate `MagicMiddleware` subclass, call `handle(next)` with mock `next` callback, assert next was/wasn't called
+- ServiceProvider tests: create `MagicApp.instance`, register provider, verify bindings with `app.make<T>('key')`
+- Validation tests: `Validator.make(data, rules)`, assert `fails()`/`passes()`, check `errors()` map
+- UI tests: `testWidgets()`, pump widget tree with `MaterialApp` wrapper. `Magic.put()` controllers in setUp
+- Event tests: register listener factory, dispatch event, verify listener `handle()` was called
+- Integration tests in `test/integration/` — test full lifecycle flows (init → use → teardown)
+- Use `group()` for logical grouping by feature/scenario. `test()` for pure logic, `testWidgets()` for widgets
+- Always `await` for: `tester.pumpWidget()`, `tester.tap()`, `tester.pump()`, `tester.pumpAndSettle()`

--- a/.github/instructions/ui.instructions.md
+++ b/.github/instructions/ui.instructions.md
@@ -1,0 +1,23 @@
+---
+name: 'Ui Conventions'
+description: 'UI domain -- views, forms, feedback, responsive layout'
+applyTo: 'lib/src/ui/**/*.dart'
+---
+
+# UI Domain (Views & Forms)
+
+- `MagicView<T extends MagicController>` — stateless, auto-injects controller via `Magic.find<T>()`
+- Register controller before view: `Magic.put(UserController())` — or resolve fails
+- `MagicStatefulView<T>` + `MagicStatefulViewState<T, W>` — stateful variant with `controller` access and auto-rebuild on controller changes
+- `MagicStatefulViewState` auto-calls `controller.onInit()` in `initState()` and `controller.onClose()` in `dispose()`
+- `MagicForm(formData: form, child: ...)` — recommended pattern. Auto-extracts `formKey` and `controller` from `MagicFormData`
+- Legacy: `MagicForm(formKey: key, controller: ctrl, child: ...)` — explicit key/controller
+- `MagicFormData({'field': defaultValue}, controller: ctrl)` — form state manager with field builders
+- Form field builders: `form.field('name', rules: [Required()])`, `form.checkbox('terms')` — auto-wired validation
+- `form.validate()` — runs all field rules, returns bool
+- `form.data` — returns `Map<String, dynamic>` of current form values
+- `form.process(Future Function(Map) callback)` — async submit with `isProcessing` / `processingListenable` tracking
+- Auto-validation: `MagicForm` switches to `AutovalidateMode.always` when controller has server-side errors
+- `MagicResponsiveView` — responsive layout widget using Wind breakpoints (`sm`, `md`, `lg`, `xl`)
+- `MagicFeedback` — toast/snackbar feedback integration
+- Wind UI integration: views use `WDiv`, `WText`, `WButton` etc. for styling via `className` props

--- a/.github/instructions/validation.instructions.md
+++ b/.github/instructions/validation.instructions.md
@@ -1,0 +1,22 @@
+---
+name: 'Validation Conventions'
+description: 'Validation domain -- rules, validator, form integration'
+applyTo: 'lib/src/validation/**/*.dart'
+---
+
+# Validation Domain
+
+- `Validator.make(Map<String, dynamic> data, Map<String, List<Rule>> rules)` — factory constructor, returns Validator
+- `Rule` abstract contract: `bool passes(String attribute, dynamic value)` + `String message()` — implement both
+- Built-in rules: `Required`, `Email`, `Min(int)`, `Max(int)`, `Confirmed`, `Numeric`, `StringRule` — no `In()` rule exists
+- `validator.fails()` runs validation once (cached). Returns `true` if any rule failed
+- `validator.passes()` — inverse of `fails()`
+- `validator.errors()` — returns `Map<String, String>` of field → error message (first failure per field)
+- `validator.validate()` — throws `ValidationException` if fails. Use for fail-fast flows
+- `ValidationException` has `.errors` map and `.message` getter
+- Message resolution: `rule.message()` → check `Lang.has(key)` → `Lang.get(key, params)` → fallback raw string
+- `:attribute` placeholder in messages replaced with humanized field name (snake_case → Title Case)
+- Custom rules: implement `Rule` contract. One rule class per validation concern
+- Rules receive full data map context — enables cross-field validation (e.g., `Confirmed` checks `password_confirmation`)
+- `FormValidator` wraps Validator for Flutter Form integration — used internally by `MagicForm`
+- Rule files live in `rules/` subdirectory, contracts in `contracts/`, exceptions in `exceptions/`

--- a/.github/scripts/sync-cc-to-copilot.sh
+++ b/.github/scripts/sync-cc-to-copilot.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Sync Claude Code rules to GitHub Copilot instructions.
+# Source of truth: .claude/rules/*.md
+# Target: .github/instructions/*.instructions.md
+#
+# Usage: /bin/bash .github/scripts/sync-cc-to-copilot.sh
+
+set -eo pipefail
+
+RULES_DIR=".claude/rules"
+INSTRUCTIONS_DIR=".github/instructions"
+
+mkdir -p "$INSTRUCTIONS_DIR"
+
+get_description() {
+  case "$1" in
+    auth)       echo "Authentication domain -- guards, session restore, auth events" ;;
+    database)   echo "Database domain -- Eloquent ORM, QueryBuilder, migrations, seeders" ;;
+    flutter)    echo "Flutter/Dart stack -- imports, naming, platform splits, IoC" ;;
+    http)       echo "HTTP domain -- controllers, middleware, state management" ;;
+    routing)    echo "Routing domain -- MagicRouter, route groups, layouts, navigation" ;;
+    tests)      echo "Testing domain -- setUp, mocking, test structure, assertions" ;;
+    ui)         echo "UI domain -- views, forms, feedback, responsive layout" ;;
+    validation) echo "Validation domain -- rules, validator, form integration" ;;
+    *)          echo "${1} domain conventions" ;;
+  esac
+}
+
+count=0
+for rule in "$RULES_DIR"/*.md; do
+  name=$(basename "$rule" .md)
+  target="$INSTRUCTIONS_DIR/${name}.instructions.md"
+
+  # Extract path: from frontmatter
+  apply_to=$(sed -n 's/^path: *"\(.*\)"/\1/p' "$rule")
+
+  # Extract body (skip frontmatter between --- markers)
+  body=$(awk 'BEGIN{skip=0} /^---$/{skip++; next} skip>=2{print}' "$rule")
+
+  description=$(get_description "$name")
+  cap_name="$(echo "${name:0:1}" | tr '[:lower:]' '[:upper:]')${name:1}"
+
+  cat > "$target" <<EOF
+---
+name: '${cap_name} Conventions'
+description: '${description}'
+applyTo: '${apply_to}'
+---
+${body}
+EOF
+
+  echo "Synced: $rule -> $target"
+  count=$((count + 1))
+done
+
+echo "Done. ${count} instruction files generated."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# Magic Framework — Agent Instructions
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `flutter test` | Run all tests |
+| `flutter test test/<module>` | Run specific module tests |
+| `dart analyze` | Static analysis (zero warnings required) |
+| `dart format .` | Format all code |
+| `dart fix --apply` | Auto-fix issues |
+| `cd example && flutter run` | Run example app |
+| `dart pub publish --dry-run` | Validate before release |
+
+## Development Flow (TDD)
+
+Every feature, fix, or refactor follows red-green-refactor:
+
+1. **Red** -- Write a failing test
+2. **Green** -- Write minimum code to pass
+3. **Refactor** -- Clean up, keep tests green
+
+**Verification cycle:** Edit -> `flutter test` -> `dart analyze` -> repeat until green
+
+## Testing Conventions
+
+- `setUp()`: Always `MagicApp.reset()` + `Magic.flush()` -- clears IoC and facade caches
+- Mock via contract inheritance, not code generation -- no mockito
+- Tests mirror `lib/src/` structure in `test/`
+- Controller tests: `Magic.put<T>(controller)` to inject
+- Integration tests in `test/integration/`
+
+## CI Pipeline
+
+`ci.yml`: push/PR -> `flutter pub get` -> `flutter analyze --no-fatal-infos` -> `dart format --set-exit-if-changed` -> `flutter test --coverage`
+
+`publish.yml`: git tag -> validate (analyze + format + test) -> auto-publish to pub.dev
+
+## Git Conventions
+
+- Commit style: `type(scope): description` (conventional commits)
+- Types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`
+- Branch naming: `feat/`, `fix/`, `chore/`, `docs/`
+- Protected `master` -- all changes via PR
+
+## Post-Change Checklist
+
+After ANY source code change, sync before committing:
+
+1. `CHANGELOG.md` -- Add entry under `[Unreleased]`
+2. `doc/` -- Update relevant documentation
+3. `README.md` -- Update if new features or API changes
+4. `skills/magic-framework/` -- Update if API, facades, or patterns changed
+5. `example/` -- Update or create example usage


### PR DESCRIPTION
## Summary

- Convert Claude Code project config to GitHub Copilot equivalents
- `.github/copilot-instructions.md` — architecture, conventions, gotchas (2.8KB, under 4KB limit)
- `.github/instructions/*.instructions.md` — 8 path-scoped domain rules (auth, database, flutter, http, routing, tests, ui, validation)
- `AGENTS.md` — commands, TDD flow, CI pipeline, git conventions for coding agents
- `.github/scripts/sync-cc-to-copilot.sh` — regenerate instructions from `.claude/rules/` source of truth

## Test plan

- [x] `copilot-instructions.md` under 4,000 characters
- [x] All 8 `.instructions.md` files have valid `applyTo:` globs matching `.claude/rules/` `path:` globs
- [x] No duplicate content between copilot-instructions and instruction files
- [x] Sync script runs cleanly: `/bin/bash .github/scripts/sync-cc-to-copilot.sh`
- [ ] Verify Copilot picks up instructions in VS Code/JetBrains