### PR TITLE
feat(testing): Facade fake() ecosystem — Auth, Cache, Vault, Log (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ Features
 - **Http Faking**: `Http.fake()` enables Laravel-style HTTP faking for testing. Swap the real network driver with a `FakeNetworkDriver` that records requests and returns stubbed responses. Supports URL pattern stubs, callback stubs, and assertion methods (`assertSent`, `assertNotSent`, `assertNothingSent`, `assertSentCount`). (#18)
+- **Facade Faking**: `Auth.fake()`, `Cache.fake()`, `Vault.fake()`, `Log.fake()` — Laravel-style facade faking for testing. Swap real service implementations with in-memory fakes that record operations and expose assertion helpers. (#19)
 
 ## [1.0.0-alpha.5] - 2026-03-29
 

--- a/doc/testing/facades.md
+++ b/doc/testing/facades.md
@@ -1,0 +1,481 @@
+# Facade Testing
+
+- [Introduction](#introduction)
+- [Auth.fake()](#auth-fake)
+- [Cache.fake()](#cache-fake)
+- [Vault.fake()](#vault-fake)
+- [Log.fake()](#log-fake)
+- [Full Example](#full-example)
+- [Unfaking](#unfaking)
+
+<a name="introduction"></a>
+## Introduction
+
+Magic provides a first-class facade faking API for Auth, Cache, Vault, and Log. Each facade exposes a `fake()` static method that swaps the IoC-bound service with an in-memory implementation for the duration of a test. No real credentials, storage, or output is touched.
+
+Call `fake()` in `setUp` and `unfake()` in `tearDown`:
+
+```dart
+setUp(() {
+  MagicApp.reset();
+  Magic.flush();
+
+  final authFake = Auth.fake();
+  final cacheFake = Cache.fake();
+  final vaultFake = Vault.fake();
+  final logFake = Log.fake();
+});
+
+tearDown(() {
+  Auth.unfake();
+  Cache.unfake();
+  Vault.unfake();
+  Log.unfake();
+});
+```
+
+Each `fake()` call returns its fake instance so you can run assertions after the code under test executes.
+
+<a name="auth-fake"></a>
+## Auth.fake()
+
+`Auth.fake()` replaces the real `AuthManager` with a `FakeAuthManager` that routes all guard operations through an in-memory `_FakeGuard`. No platform channels, no secure storage, no token refresh calls.
+
+**Signature:**
+
+```dart
+static FakeAuthManager fake({Authenticatable? user})
+```
+
+Pass `user` to pre-authenticate before the test body runs.
+
+### Basic Usage
+
+```dart
+test('dashboard redirects guests to login', () {
+  Auth.fake(); // No user — guest state
+
+  expect(Auth.check(), isFalse);
+  expect(Auth.guest, isTrue);
+});
+
+test('user is pre-authenticated', () {
+  final user = User()..fill({'id': 1, 'name': 'Alice'});
+  Auth.fake(user: user);
+
+  expect(Auth.check(), isTrue);
+  expect(Auth.user<User>()?.name, 'Alice');
+});
+```
+
+### Assertions
+
+| Method | Description |
+|--------|-------------|
+| `fake.assertLoggedIn()` | Assert a user is currently authenticated. |
+| `fake.assertLoggedOut()` | Assert no user is currently authenticated. |
+| `fake.assertLoginAttempted()` | Assert at least one login call was made. |
+| `fake.assertLoginCount(int expected)` | Assert an exact number of login calls. |
+
+```dart
+test('controller logs in user on success', () async {
+  final user = User()..fill({'id': 1, 'name': 'Alice'});
+  final fake = Auth.fake();
+
+  await Auth.login({'token': 'test-token'}, user);
+
+  fake.assertLoggedIn();
+  fake.assertLoginAttempted();
+  fake.assertLoginCount(1);
+});
+
+test('controller logs out user', () async {
+  final user = User()..fill({'id': 1, 'name': 'Alice'});
+  final fake = Auth.fake(user: user);
+
+  await Auth.logout();
+
+  fake.assertLoggedOut();
+});
+```
+
+### Resetting State
+
+Call `fake.reset()` to clear the current user, token, and login attempt records without restoring the real driver:
+
+```dart
+fake.reset(); // Clears user, token, and login attempt history
+```
+
+<a name="cache-fake"></a>
+## Cache.fake()
+
+`Cache.fake()` replaces the real `CacheManager` with a `FakeCacheManager` backed by a plain `Map`. All operations are synchronous and in-memory. Every `put`, `get`, and `forget` call is recorded in `fake.recorded`.
+
+**Signature:**
+
+```dart
+static FakeCacheManager fake()
+```
+
+### Basic Usage
+
+```dart
+test('controller caches user list', () async {
+  final fake = Cache.fake();
+
+  await Cache.put('users', ['Alice', 'Bob'], ttl: Duration(minutes: 5));
+
+  expect(Cache.has('users'), isTrue);
+  expect(Cache.get('users'), equals(['Alice', 'Bob']));
+});
+```
+
+### Assertions
+
+| Method | Description |
+|--------|-------------|
+| `fake.assertHas(String key)` | Assert that the key currently exists in the cache. |
+| `fake.assertMissing(String key)` | Assert that the key does not exist in the cache. |
+| `fake.assertPut(String key)` | Assert that the key was stored via `put` at least once. |
+
+```dart
+test('user list is cached after fetch', () async {
+  final fake = Cache.fake();
+
+  await Cache.put('users', ['Alice', 'Bob']);
+
+  fake.assertHas('users');
+  fake.assertPut('users');
+});
+
+test('cache is cleared after flush', () async {
+  final fake = Cache.fake();
+
+  await Cache.put('users', ['Alice']);
+  await Cache.flush();
+
+  fake.assertMissing('users');
+});
+```
+
+### Recorded Operations
+
+Access `fake.recorded` for a full chronological list of cache operations:
+
+```dart
+final fake = Cache.fake();
+
+await Cache.put('a', 1);
+await Cache.get('a');
+await Cache.forget('a');
+
+expect(fake.recorded[0].operation, 'put');
+expect(fake.recorded[1].operation, 'get');
+expect(fake.recorded[2].operation, 'forget');
+```
+
+Each entry is a `CacheRecord` record type: `({String operation, String key, dynamic value})`.
+
+### Resetting State
+
+Call `fake.reset()` to clear both the in-memory store and the recorded operations list:
+
+```dart
+fake.reset();
+```
+
+<a name="vault-fake"></a>
+## Vault.fake()
+
+`Vault.fake()` replaces the real `MagicVaultService` (backed by `flutter_secure_storage`) with a `FakeVaultService` that stores data in a plain `Map`. No platform channels are invoked.
+
+**Signature:**
+
+```dart
+static FakeVaultService fake([Map<String, String> initialValues = const {}])
+```
+
+Pass `initialValues` to pre-seed the vault before the test body runs.
+
+### Basic Usage
+
+```dart
+test('controller reads token from vault', () async {
+  Vault.fake({'auth_token': 'seed-token'});
+
+  final token = await Vault.get('auth_token');
+
+  expect(token, 'seed-token');
+});
+
+test('controller writes token to vault', () async {
+  final fake = Vault.fake();
+
+  await Vault.put('auth_token', 'abc123');
+
+  expect(await Vault.get('auth_token'), 'abc123');
+});
+```
+
+### Assertions
+
+| Method | Description |
+|--------|-------------|
+| `fake.assertWritten(String key)` | Assert that `key` was written via `put` at least once. |
+| `fake.assertDeleted(String key)` | Assert that `key` was deleted via `delete` at least once. |
+| `fake.assertContains(String key)` | Assert that `key` currently exists in the store. |
+| `fake.assertMissing(String key)` | Assert that `key` does not currently exist in the store. |
+
+```dart
+test('logout clears auth token', () async {
+  final fake = Vault.fake({'auth_token': 'abc123'});
+
+  await Vault.delete('auth_token');
+
+  fake.assertDeleted('auth_token');
+  fake.assertMissing('auth_token');
+});
+
+test('login stores token in vault', () async {
+  final fake = Vault.fake();
+
+  await Vault.put('auth_token', 'new-token');
+
+  fake.assertWritten('auth_token');
+  fake.assertContains('auth_token');
+});
+```
+
+### Recorded Operations
+
+Access `fake.recorded` for a full list of vault operations:
+
+```dart
+final fake = Vault.fake();
+
+await Vault.put('token', 'abc');
+await Vault.get('token');
+await Vault.delete('token');
+
+expect(fake.recorded[0].operation, 'put');
+expect(fake.recorded[1].operation, 'get');
+expect(fake.recorded[2].operation, 'remove');
+```
+
+Each entry is a `VaultOperation` record type: `({String operation, String key})`.
+
+### Resetting State
+
+Call `fake.reset()` to clear the in-memory store and recorded operations:
+
+```dart
+fake.reset();
+```
+
+<a name="log-fake"></a>
+## Log.fake()
+
+`Log.fake()` replaces the real `LogManager` with a `FakeLogManager` that captures all log entries in memory instead of writing to the console.
+
+**Signature:**
+
+```dart
+static FakeLogManager fake()
+```
+
+### Basic Usage
+
+```dart
+test('controller logs error on failure', () async {
+  final fake = Log.fake();
+
+  Log.error('Payment failed', {'order': 42});
+
+  fake.assertLoggedError('Payment failed');
+});
+```
+
+### Assertions
+
+| Method | Description |
+|--------|-------------|
+| `fake.assertLogged(String level, String message)` | Assert at least one entry matches both level and message. |
+| `fake.assertLoggedError(String message)` | Shorthand for `assertLogged('error', message)`. |
+| `fake.assertNothingLogged([String? level])` | Assert no entries recorded. If `level` is given, assert no entries at that level. |
+| `fake.assertLoggedCount(int expected)` | Assert an exact total number of entries recorded. |
+
+```dart
+test('no logs emitted during normal operation', () {
+  final fake = Log.fake();
+
+  doNormalWork();
+
+  fake.assertNothingLogged();
+});
+
+test('exactly one error is logged', () async {
+  final fake = Log.fake();
+
+  Log.error('Something failed');
+
+  fake.assertLoggedCount(1);
+  fake.assertLoggedError('Something failed');
+});
+
+test('warning is logged at correct level', () {
+  final fake = Log.fake();
+
+  Log.warning('Rate limit approaching');
+
+  fake.assertLogged('warning', 'Rate limit approaching');
+  fake.assertNothingLogged('error'); // No errors logged
+});
+```
+
+### Inspecting Entries
+
+Access `fake.entries` for the full list of captured log entries:
+
+```dart
+final fake = Log.fake();
+
+Log.info('User logged in', {'id': 1});
+Log.error('Token expired');
+
+expect(fake.entries.length, 2);
+expect(fake.entries[0].level, 'info');
+expect(fake.entries[0].message, 'User logged in');
+expect(fake.entries[1].level, 'error');
+```
+
+Each entry is a `FakeLogEntry` record type: `({String level, String message, dynamic context})`.
+
+### Resetting State
+
+Call `fake.reset()` to clear all captured entries without restoring the real driver:
+
+```dart
+fake.reset();
+```
+
+<a name="full-example"></a>
+## Full Example
+
+A controller that integrates Auth, Cache, Vault, and Log, with tests covering all four fakes:
+
+```dart
+// lib/controllers/session_controller.dart
+class SessionController extends MagicController {
+  Future<void> login(String token, User user) async {
+    await Auth.login({'token': token}, user);
+    await Vault.put('auth_token', token);
+    await Cache.put('current_user', user.toMap());
+    Log.info('User logged in', {'id': user.id});
+  }
+
+  Future<void> logout() async {
+    await Auth.logout();
+    await Vault.delete('auth_token');
+    await Cache.forget('current_user');
+    Log.info('User logged out');
+  }
+}
+
+// test/http/session_controller_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+
+void main() {
+  group('SessionController', () {
+    late SessionController controller;
+    late FakeAuthManager authFake;
+    late FakeCacheManager cacheFake;
+    late FakeVaultService vaultFake;
+    late FakeLogManager logFake;
+
+    setUp(() {
+      MagicApp.reset();
+      Magic.flush();
+
+      controller = SessionController();
+      authFake = Auth.fake();
+      cacheFake = Cache.fake();
+      vaultFake = Vault.fake();
+      logFake = Log.fake();
+    });
+
+    tearDown(() {
+      Auth.unfake();
+      Cache.unfake();
+      Vault.unfake();
+      Log.unfake();
+    });
+
+    test('login authenticates user and stores credentials', () async {
+      final user = User()..fill({'id': 1, 'name': 'Alice'});
+
+      await controller.login('token-abc', user);
+
+      authFake.assertLoggedIn();
+      authFake.assertLoginCount(1);
+      vaultFake.assertWritten('auth_token');
+      vaultFake.assertContains('auth_token');
+      cacheFake.assertHas('current_user');
+      cacheFake.assertPut('current_user');
+      logFake.assertLogged('info', 'User logged in');
+    });
+
+    test('logout clears all session state', () async {
+      final user = User()..fill({'id': 1, 'name': 'Alice'});
+      authFake = Auth.fake(user: user);
+      vaultFake = Vault.fake({'auth_token': 'token-abc'});
+
+      await controller.logout();
+
+      authFake.assertLoggedOut();
+      vaultFake.assertDeleted('auth_token');
+      vaultFake.assertMissing('auth_token');
+      cacheFake.assertMissing('current_user');
+      logFake.assertLogged('info', 'User logged out');
+    });
+  });
+}
+```
+
+<a name="unfaking"></a>
+## Unfaking
+
+Call `unfake()` in `tearDown` to remove the fake from the IoC container and restore the real service binding for subsequent tests:
+
+```dart
+tearDown(() {
+  Auth.unfake();
+  Cache.unfake();
+  Vault.unfake();
+  Log.unfake();
+});
+```
+
+After `unfake()`, the next facade call resolves the original singleton binding as if `fake()` was never called. This is the recommended pattern when each test should start from a clean real-service state.
+
+If you want to reuse the same fake across multiple tests in a group without restoring the real driver, call `fake.reset()` instead:
+
+```dart
+final logFake = Log.fake(); // Install once for the group
+
+test('first', () {
+  Log.error('a');
+  logFake.assertLoggedCount(1);
+  logFake.reset(); // Clear for next test — fake remains installed
+});
+
+test('second', () {
+  Log.error('b');
+  logFake.assertLoggedCount(1);
+});
+```
+
+## See Also
+
+- [HTTP Tests](http-tests.md) — `Http.fake()`, URL pattern stubs, request assertions

--- a/doc/testing/http-tests.md
+++ b/doc/testing/http-tests.md
@@ -309,3 +309,7 @@ void main() {
   });
 }
 ```
+
+## See Also
+
+- [Facade Testing](facades.md) — `Auth.fake()`, `Cache.fake()`, `Vault.fake()`, `Log.fake()`

--- a/lib/magic.dart
+++ b/lib/magic.dart
@@ -95,6 +95,12 @@ export 'src/logging/log_manager.dart';
 
 export 'src/facades/log.dart';
 
+// Testing
+export 'src/testing/fake_auth_manager.dart';
+export 'src/testing/fake_cache_manager.dart';
+export 'src/testing/fake_vault_service.dart';
+export 'src/testing/fake_log_manager.dart';
+
 // Database
 export 'src/database/database_manager.dart';
 export 'src/database/database_service_provider.dart';

--- a/lib/src/auth/auth_manager.dart
+++ b/lib/src/auth/auth_manager.dart
@@ -40,6 +40,9 @@ class AuthManager {
 
   AuthManager._internal();
 
+  /// Named constructor for testing — allows subclasses to bypass the singleton.
+  AuthManager.forTesting() : _userFactory = null;
+
   /// Resolved guard instances.
   final Map<String, Guard> _guards = {};
 

--- a/lib/src/facades/auth.dart
+++ b/lib/src/facades/auth.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/foundation.dart';
 
 import '../auth/auth_manager.dart';
-import '../auth/contracts/guard.dart';
 import '../auth/authenticatable.dart';
+import '../auth/contracts/guard.dart';
 import '../database/eloquent/model.dart';
+import '../foundation/magic.dart';
+import '../testing/fake_auth_manager.dart';
 
 /// The Auth Facade.
 ///
@@ -38,7 +40,7 @@ import '../database/eloquent/model.dart';
 /// ```
 class Auth {
   /// The auth manager instance.
-  static final AuthManager _manager = AuthManager();
+  static AuthManager get _manager => Magic.make<AuthManager>('auth');
 
   /// Get the auth manager.
   static AuthManager get manager => _manager;
@@ -190,4 +192,26 @@ class Auth {
   /// Auth.stateNotifier.addListener(() => setState(() {}));
   /// ```
   static ValueNotifier<int> get stateNotifier => guard().stateNotifier;
+
+  // ---------------------------------------------------------------------------
+  // Testing
+  // ---------------------------------------------------------------------------
+
+  /// Replace the auth manager with a [FakeAuthManager] for testing.
+  ///
+  /// Optionally pre-authenticates with the given [user].
+  ///
+  /// ```dart
+  /// final fake = Auth.fake(user: myUser);
+  /// expect(Auth.check(), isTrue);
+  /// fake.assertLoggedIn();
+  /// ```
+  static FakeAuthManager fake({Authenticatable? user}) {
+    final driver = FakeAuthManager(user: user);
+    Magic.app.setInstance('auth', driver);
+    return driver;
+  }
+
+  /// Remove the fake and restore normal auth resolution.
+  static void unfake() => Magic.app.removeInstance('auth');
 }

--- a/lib/src/facades/cache.dart
+++ b/lib/src/facades/cache.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import '../cache/cache_manager.dart';
 import '../foundation/magic.dart';
+import '../testing/fake_cache_manager.dart';
 
 /// Laravel-style Cache Facade.
 ///
@@ -91,4 +92,27 @@ class Cache {
     await put(key, value, ttl: ttl);
     return value;
   }
+
+  // ---------------------------------------------------------------------------
+  // Testing
+  // ---------------------------------------------------------------------------
+
+  /// Swap the real cache manager with a [FakeCacheManager] for testing.
+  ///
+  /// ```dart
+  /// final fake = Cache.fake();
+  /// await Cache.put('key', 'value');
+  /// fake.assertHas('key');
+  /// ```
+  static FakeCacheManager fake() {
+    final driver = FakeCacheManager();
+    Magic.app.setInstance('cache', driver);
+    return driver;
+  }
+
+  /// Restore the real cache manager after faking.
+  ///
+  /// Removes the fake instance so the next call resolves
+  /// the original singleton binding.
+  static void unfake() => Magic.app.removeInstance('cache');
 }

--- a/lib/src/facades/log.dart
+++ b/lib/src/facades/log.dart
@@ -1,5 +1,6 @@
 import '../foundation/magic.dart';
 import '../logging/log_manager.dart';
+import '../testing/fake_log_manager.dart';
 
 /// The Log Facade.
 ///
@@ -54,4 +55,28 @@ class Log {
   /// Log.channel('slack').error('Server down!');
   /// ```
   static LogManager channel(String name) => _manager;
+
+  /// Replace the bound [LogManager] with a [FakeLogManager] for testing.
+  ///
+  /// Returns the [FakeLogManager] so callers can make assertions.
+  ///
+  /// ```dart
+  /// final fake = Log.fake();
+  ///
+  /// Log.error('Something failed');
+  ///
+  /// fake.assertLoggedError('Something failed');
+  /// ```
+  static FakeLogManager fake() {
+    final driver = FakeLogManager();
+    Magic.app.setInstance('log', driver);
+    return driver;
+  }
+
+  /// Restore the real [LogManager] binding, removing the fake.
+  ///
+  /// ```dart
+  /// Log.unfake();
+  /// ```
+  static void unfake() => Magic.app.removeInstance('log');
 }

--- a/lib/src/facades/vault.dart
+++ b/lib/src/facades/vault.dart
@@ -1,5 +1,6 @@
 import '../foundation/magic.dart';
 import '../security/magic_vault_service.dart';
+import '../testing/fake_vault_service.dart';
 
 /// The Vault Facade.
 ///
@@ -35,4 +36,30 @@ class Vault {
   static Future<void> flush() async {
     return _service.flush();
   }
+
+  // ---------------------------------------------------------------------------
+  // Testing helpers
+  // ---------------------------------------------------------------------------
+
+  /// Swap the vault service with a [FakeVaultService] for testing.
+  ///
+  /// Returns the fake so tests can inspect recorded operations and run
+  /// assertions.
+  ///
+  /// ```dart
+  /// final fake = Vault.fake({'token': 'seed_value'});
+  /// await Vault.put('key', 'value');
+  /// fake.assertWritten('key');
+  /// ```
+  static FakeVaultService fake([Map<String, String> initialValues = const {}]) {
+    final driver = FakeVaultService(initialValues);
+    Magic.app.setInstance('vault', driver);
+    return driver;
+  }
+
+  /// Remove the [FakeVaultService] from the container.
+  ///
+  /// After this call the container falls back to its registered binding,
+  /// restoring normal resolution behaviour.
+  static void unfake() => Magic.app.removeInstance('vault');
 }

--- a/lib/src/security/magic_vault_service.dart
+++ b/lib/src/security/magic_vault_service.dart
@@ -29,6 +29,13 @@ class MagicVaultService {
     );
   }
 
+  /// Named constructor for testing — skips [FlutterSecureStorage] initialisation.
+  ///
+  /// Use this as the `super` constructor in [FakeVaultService] so that the
+  /// `late final _storage` field is never assigned and therefore never accessed.
+  // ignore: avoid_unused_constructor_parameters
+  MagicVaultService.forTesting();
+
   /// Store a value in the vault.
   Future<void> put(String key, String value) async {
     try {

--- a/lib/src/testing/fake_auth_manager.dart
+++ b/lib/src/testing/fake_auth_manager.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/foundation.dart';
+
+import '../auth/auth_manager.dart';
+import '../auth/authenticatable.dart';
+import '../auth/contracts/guard.dart';
+import '../database/eloquent/model.dart';
+
+/// A fake [AuthManager] for testing.
+///
+/// Routes all guard operations through an in-memory [_FakeGuard] instead of
+/// resolving real guards from config. Supports assertions and login tracking.
+///
+/// ```dart
+/// final fake = Auth.fake(user: myUser);
+///
+/// expect(Auth.check(), isTrue);
+/// expect(Auth.user<User>(), same(myUser));
+///
+/// await Auth.logout();
+/// fake.assertLoggedOut();
+/// ```
+class FakeAuthManager extends AuthManager {
+  /// The internal fake guard used for all guard resolutions.
+  final _FakeGuard _fakeGuard;
+
+  /// Creates a fake auth manager.
+  ///
+  /// Optionally pre-authenticates with the given [user].
+  FakeAuthManager({Authenticatable? user})
+    : _fakeGuard = _FakeGuard(user: user),
+      super.forTesting();
+
+  /// Always returns the internal [_FakeGuard], regardless of guard name.
+  @override
+  Guard guard([String? name]) => _fakeGuard;
+
+  /// Clears the fake guard state.
+  @override
+  void forgetGuards() {
+    _fakeGuard.reset();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Assertions
+  // ---------------------------------------------------------------------------
+
+  /// Assert that a user is currently authenticated.
+  ///
+  /// Throws [AssertionError] if no user is set.
+  void assertLoggedIn() {
+    if (!_fakeGuard.check()) {
+      throw AssertionError(
+        'Expected a user to be authenticated but none was found.',
+      );
+    }
+  }
+
+  /// Assert that no user is currently authenticated.
+  ///
+  /// Throws [AssertionError] if a user is set.
+  void assertLoggedOut() {
+    if (_fakeGuard.check()) {
+      throw AssertionError('Expected no authenticated user but one was found.');
+    }
+  }
+
+  /// Assert that at least one login attempt was made.
+  ///
+  /// Throws [AssertionError] if no login calls were recorded.
+  void assertLoginAttempted() {
+    if (_fakeGuard._loginAttempts.isEmpty) {
+      throw AssertionError(
+        'Expected at least one login attempt but none were recorded.',
+      );
+    }
+  }
+
+  /// Assert that exactly [expected] login attempts were made.
+  ///
+  /// Throws [AssertionError] if the count does not match.
+  void assertLoginCount(int expected) {
+    final actual = _fakeGuard._loginAttempts.length;
+    if (actual != expected) {
+      throw AssertionError(
+        'Expected $expected login attempt(s) but found $actual.',
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reset
+  // ---------------------------------------------------------------------------
+
+  /// Clear all fake state — user, token, and login attempts.
+  void reset() {
+    _fakeGuard.reset();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal fake guard
+// ---------------------------------------------------------------------------
+
+class _FakeGuard implements Guard {
+  Authenticatable? _user;
+  String? _token;
+  final List<Map<String, dynamic>> _loginAttempts = [];
+
+  @override
+  final ValueNotifier<int> stateNotifier = ValueNotifier<int>(0);
+
+  _FakeGuard({Authenticatable? user}) : _user = user;
+
+  @override
+  bool check() => _user != null;
+
+  @override
+  bool get guest => !check();
+
+  @override
+  T? user<T extends Model>() => _user as T?;
+
+  @override
+  dynamic id() => _user?.authIdentifier;
+
+  @override
+  void setUser(Authenticatable user) {
+    _user = user;
+  }
+
+  @override
+  Future<void> login(Map<String, dynamic> data, Authenticatable user) async {
+    _user = user;
+    _token = data['token'] as String?;
+    _loginAttempts.add(data);
+    stateNotifier.value++;
+  }
+
+  @override
+  Future<void> logout() async {
+    _user = null;
+    _token = null;
+    stateNotifier.value++;
+  }
+
+  @override
+  Future<bool> hasToken() => Future<bool>.value(_token != null);
+
+  @override
+  Future<String?> getToken() => Future<String?>.value(_token);
+
+  @override
+  Future<bool> refreshToken() => Future<bool>.value(false);
+
+  @override
+  Future<void> restore() => Future<void>.value();
+
+  /// Reset all internal state.
+  void reset() {
+    _user = null;
+    _token = null;
+    _loginAttempts.clear();
+  }
+}

--- a/lib/src/testing/fake_cache_manager.dart
+++ b/lib/src/testing/fake_cache_manager.dart
@@ -1,0 +1,138 @@
+import '../cache/cache_manager.dart';
+import '../cache/cache_store.dart';
+
+/// A recorded cache operation entry.
+typedef CacheRecord = ({String operation, String key, dynamic value});
+
+/// A fake [CacheManager] for testing.
+///
+/// Routes all cache operations through an in-memory store instead of a
+/// real driver. Supports assertions and operation recording.
+///
+/// ```dart
+/// final fake = Cache.fake();
+///
+/// await Cache.put('user', 'alice');
+///
+/// fake.assertHas('user');
+/// fake.assertPut('user');
+/// ```
+class FakeCacheManager extends CacheManager {
+  final _InMemoryCacheStore _store = _InMemoryCacheStore();
+
+  /// All recorded cache operations in chronological order.
+  final List<CacheRecord> recorded = [];
+
+  @override
+  CacheStore driver([String? driver]) => _store;
+
+  // ---------------------------------------------------------------------------
+  // Proxy — record every operation then delegate
+  // ---------------------------------------------------------------------------
+
+  @override
+  dynamic get(String key, {dynamic defaultValue}) {
+    final value = _store.get(key, defaultValue: defaultValue);
+    recorded.add((operation: 'get', key: key, value: value));
+    return value;
+  }
+
+  @override
+  Future<void> put(String key, dynamic value, {Duration? ttl}) async {
+    await _store.put(key, value, ttl: ttl);
+    recorded.add((operation: 'put', key: key, value: value));
+  }
+
+  @override
+  bool has(String key) => _store.has(key);
+
+  @override
+  Future<void> forget(String key) async {
+    await _store.forget(key);
+    recorded.add((operation: 'forget', key: key, value: null));
+  }
+
+  @override
+  Future<void> flush() async {
+    await _store.flush();
+    recorded.add((operation: 'flush', key: '', value: null));
+  }
+
+  @override
+  Future<void> init() => Future<void>.value();
+
+  // ---------------------------------------------------------------------------
+  // Assertions
+  // ---------------------------------------------------------------------------
+
+  /// Assert that [key] currently exists in the cache store.
+  void assertHas(String key) {
+    if (!_store.has(key)) {
+      throw AssertionError(
+        'Expected cache to have key "$key" but it was missing.',
+      );
+    }
+  }
+
+  /// Assert that [key] does not exist in the cache store.
+  void assertMissing(String key) {
+    if (_store.has(key)) {
+      throw AssertionError(
+        'Expected cache to be missing key "$key" but it was present.',
+      );
+    }
+  }
+
+  /// Assert that [key] was stored via [put] at least once.
+  void assertPut(String key) {
+    final wasPut = recorded.any((r) => r.operation == 'put' && r.key == key);
+    if (!wasPut) {
+      throw AssertionError(
+        'Expected cache key "$key" to have been put but it was never stored.',
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reset
+  // ---------------------------------------------------------------------------
+
+  /// Clear the store and all recorded operations.
+  void reset() {
+    _store._data.clear();
+    recorded.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal in-memory store
+// ---------------------------------------------------------------------------
+
+class _InMemoryCacheStore implements CacheStore {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  Future<void> init() => Future<void>.value();
+
+  @override
+  dynamic get(String key, {dynamic defaultValue}) =>
+      _data.containsKey(key) ? _data[key] : defaultValue;
+
+  @override
+  Future<void> put(String key, dynamic value, {Duration? ttl}) async {
+    _data[key] = value;
+  }
+
+  @override
+  bool has(String key) => _data.containsKey(key);
+
+  @override
+  Future<void> forget(String key) async {
+    _data.remove(key);
+  }
+
+  @override
+  Future<void> flush() async {
+    _data.clear();
+  }
+}

--- a/lib/src/testing/fake_log_manager.dart
+++ b/lib/src/testing/fake_log_manager.dart
@@ -1,0 +1,109 @@
+import '../logging/contracts/logger_driver.dart';
+import '../logging/log_manager.dart';
+
+/// A single captured log entry.
+typedef FakeLogEntry = ({String level, String message, dynamic context});
+
+/// A fake [LogManager] for testing.
+///
+/// Captures all log calls in memory instead of writing to console.
+/// Provides assertion helpers for verifying expected log activity.
+///
+/// ```dart
+/// final fake = Log.fake();
+///
+/// Log.error('Payment failed');
+///
+/// fake.assertLoggedError('Payment failed');
+/// fake.assertLoggedCount(1);
+/// ```
+class FakeLogManager extends LogManager {
+  final _FakeLoggerDriver _driver = _FakeLoggerDriver();
+
+  /// All captured log entries in chronological order.
+  List<FakeLogEntry> get entries => List.unmodifiable(_driver._entries);
+
+  @override
+  LoggerDriver driver([String? channel]) => _driver;
+
+  // ---------------------------------------------------------------------------
+  // Assertions
+  // ---------------------------------------------------------------------------
+
+  /// Assert that at least one entry matches both [level] and [message].
+  ///
+  /// Throws [AssertionError] if no matching entry is found.
+  void assertLogged(String level, String message) {
+    final matched = _driver._entries.any(
+      (e) => e.level == level && e.message == message,
+    );
+
+    if (!matched) {
+      throw AssertionError(
+        'Expected a log entry at level "$level" with message "$message" '
+        'but none was found.',
+      );
+    }
+  }
+
+  /// Assert that at least one error-level entry matches [message].
+  ///
+  /// Shorthand for `assertLogged('error', message)`.
+  void assertLoggedError(String message) => assertLogged('error', message);
+
+  /// Assert that no entries exist, or no entries exist at [level].
+  ///
+  /// If [level] is null, asserts the log is completely empty.
+  /// If [level] is provided, asserts no entries exist at that level.
+  ///
+  /// Throws [AssertionError] on failure.
+  void assertNothingLogged([String? level]) {
+    if (level == null) {
+      if (_driver._entries.isNotEmpty) {
+        throw AssertionError(
+          'Expected no log entries but ${_driver._entries.length} were recorded.',
+        );
+      }
+    } else {
+      final atLevel = _driver._entries.where((e) => e.level == level).toList();
+      if (atLevel.isNotEmpty) {
+        throw AssertionError(
+          'Expected no log entries at level "$level" but '
+          '${atLevel.length} were recorded.',
+        );
+      }
+    }
+  }
+
+  /// Assert that exactly [expected] entries were recorded in total.
+  ///
+  /// Throws [AssertionError] if the count does not match.
+  void assertLoggedCount(int expected) {
+    final actual = _driver._entries.length;
+    if (actual != expected) {
+      throw AssertionError(
+        'Expected $expected log entries but $actual were recorded.',
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reset
+  // ---------------------------------------------------------------------------
+
+  /// Clear all captured entries.
+  void reset() => _driver._entries.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Internal fake driver — captures entries, no console output
+// ---------------------------------------------------------------------------
+
+class _FakeLoggerDriver extends LoggerDriver {
+  final List<FakeLogEntry> _entries = [];
+
+  @override
+  void log(String level, String message, [dynamic context]) {
+    _entries.add((level: level, message: message, context: context));
+  }
+}

--- a/lib/src/testing/fake_vault_service.dart
+++ b/lib/src/testing/fake_vault_service.dart
@@ -1,0 +1,116 @@
+import '../security/magic_vault_service.dart';
+
+/// A record of a vault operation for test assertions.
+typedef VaultOperation = ({String operation, String key});
+
+/// In-memory fake implementation of [MagicVaultService] for testing.
+///
+/// Replaces [FlutterSecureStorage] with a simple [Map] so tests run
+/// without platform channels.
+///
+/// ## Usage
+///
+/// ```dart
+/// final fake = Vault.fake({'token': 'abc123'});
+/// await Vault.put('key', 'value');
+/// fake.assertWritten('key');
+/// fake.assertContains('key');
+/// Vault.unfake();
+/// ```
+class FakeVaultService extends MagicVaultService {
+  final Map<String, String> _store = {};
+  final List<VaultOperation> _recorded = [];
+
+  /// Creates a [FakeVaultService] with optional [initialValues].
+  FakeVaultService([Map<String, String> initialValues = const {}])
+    : super.forTesting() {
+    _store.addAll(initialValues);
+  }
+
+  /// All recorded operations in the order they were performed.
+  List<VaultOperation> get recorded => List.unmodifiable(_recorded);
+
+  // ---------------------------------------------------------------------------
+  // MagicVaultService overrides
+  // ---------------------------------------------------------------------------
+
+  @override
+  Future<void> put(String key, String value) async {
+    _store[key] = value;
+    _recorded.add((operation: 'put', key: key));
+  }
+
+  @override
+  Future<String?> get(String key) async {
+    _recorded.add((operation: 'get', key: key));
+    return _store[key];
+  }
+
+  @override
+  Future<void> remove(String key) async {
+    _store.remove(key);
+    _recorded.add((operation: 'remove', key: key));
+  }
+
+  @override
+  Future<void> flush() async {
+    _store.clear();
+    _recorded.add((operation: 'flush', key: ''));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Assertions
+  // ---------------------------------------------------------------------------
+
+  /// Assert that [key] was written (via [put]) at least once.
+  void assertWritten(String key) {
+    final wasWritten = _recorded.any(
+      (r) => r.operation == 'put' && r.key == key,
+    );
+    if (!wasWritten) {
+      throw AssertionError(
+        'Expected vault key "$key" to have been written, but it was not.',
+      );
+    }
+  }
+
+  /// Assert that [key] was deleted (via [remove]) at least once.
+  void assertDeleted(String key) {
+    final wasDeleted = _recorded.any(
+      (r) => r.operation == 'remove' && r.key == key,
+    );
+    if (!wasDeleted) {
+      throw AssertionError(
+        'Expected vault key "$key" to have been deleted, but it was not.',
+      );
+    }
+  }
+
+  /// Assert that [key] currently exists in the store.
+  void assertContains(String key) {
+    if (!_store.containsKey(key)) {
+      throw AssertionError(
+        'Expected vault to contain key "$key", but it was missing.',
+      );
+    }
+  }
+
+  /// Assert that [key] does not currently exist in the store.
+  void assertMissing(String key) {
+    if (_store.containsKey(key)) {
+      throw AssertionError(
+        'Expected vault key "$key" to be missing, but it was present.',
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /// Clear the in-memory store and the recorded operations list.
+  void reset() {
+    _store.clear();
+    _recorded.clear();
+  }
+}

--- a/skills/magic-framework/references/facades-api.md
+++ b/skills/magic-framework/references/facades-api.md
@@ -26,6 +26,8 @@ Proxies calls to the default guard via the `AuthManager` singleton.
 | `Auth.manager.setUserFactory(Authenticatable Function(Map<String, dynamic>) f)` | `void` | **Required** in `ServiceProvider.boot()` — auth won't work without it. |
 | `Auth.manager.extend(String name, Guard Function(Map) f)` | `void` | Register a custom authentication guard. |
 | `Auth.stateNotifier` | `ValueNotifier<int>` | **Getter.** Bumps on every login/logout/restore — use in layout widgets to rebuild reactively. |
+| `Auth.fake({Authenticatable? user})` | `FakeAuthManager` | **Testing.** Swap real `AuthManager` with `FakeAuthManager`. Pass `user` to pre-authenticate. Returns fake for assertions (`assertLoggedIn`, `assertLoggedOut`, `assertLoginAttempted`, `assertLoginCount`). |
+| `Auth.unfake()` | `void` | **Testing.** Remove fake and restore real `AuthManager`. Call in `tearDown`. |
 
 ```dart
 import 'package:magic/magic.dart';
@@ -65,6 +67,8 @@ Resolves `Magic.make<CacheManager>('cache')`.
 | `Cache.forget(String key)` | `Future<void>` | Remove a single cache item. |
 | `Cache.flush()` | `Future<void>` | Clear all items from the current cache driver. |
 | `Cache.remember<T>(String key, Duration ttl, Future<T> Function() callback)` | `Future<T>` | Return cached value or execute callback, store, and return. |
+| `Cache.fake()` | `FakeCacheManager` | **Testing.** Swap real `CacheManager` with in-memory `FakeCacheManager` that records operations. Returns fake for assertions (`assertHas`, `assertMissing`, `assertPut`). |
+| `Cache.unfake()` | `void` | **Testing.** Remove fake and restore real `CacheManager`. Call in `tearDown`. |
 
 ```dart
 import 'package:magic/magic.dart';
@@ -379,6 +383,8 @@ Resolves `Magic.make<LogManager>('log')`. Supports all RFC 5424 levels.
 | `Log.debug(String message, [dynamic context])` | `void` | Detailed debug information. |
 | `Log.log(String level, String message, [dynamic context])` | `void` | Log at an arbitrary level string. |
 | `Log.channel(String name)` | `LogManager` | Get a named log channel. |
+| `Log.fake()` | `FakeLogManager` | **Testing.** Swap real `LogManager` with `FakeLogManager` that captures entries in memory (no console output). Returns fake for assertions (`assertLogged`, `assertLoggedError`, `assertNothingLogged`, `assertLoggedCount`). |
+| `Log.unfake()` | `void` | **Testing.** Remove fake and restore real `LogManager`. Call in `tearDown`. |
 
 ```dart
 import 'package:magic/magic.dart';
@@ -558,6 +564,8 @@ Resolves `Magic.make<MagicVaultService>('vault')`. Backed by `flutter_secure_sto
 | `Vault.get(String key)` | `Future<String?>` | Read value; null if key does not exist. |
 | `Vault.delete(String key)` | `Future<void>` | Remove a specific key. |
 | `Vault.flush()` | `Future<void>` | Wipe ALL secure storage data for this app. |
+| `Vault.fake([Map<String, String> initialValues = const {}])` | `FakeVaultService` | **Testing.** Swap real `MagicVaultService` with in-memory `FakeVaultService`. Pass `initialValues` to pre-seed. Returns fake for assertions (`assertWritten`, `assertDeleted`, `assertContains`, `assertMissing`). |
+| `Vault.unfake()` | `void` | **Testing.** Remove fake and restore real `MagicVaultService`. Call in `tearDown`. |
 
 ```dart
 import 'package:magic/magic.dart';

--- a/skills/magic-framework/references/testing-patterns.md
+++ b/skills/magic-framework/references/testing-patterns.md
@@ -548,6 +548,128 @@ setUp(() {
 fake.reset(); // Clears recorded + stubs
 ```
 
+## Facade Faking
+
+Magic provides built-in fakes for Auth, Cache, Vault, and Log — no third-party mock libraries needed. Each facade exposes `fake()` / `unfake()` methods that swap the IoC-bound service with an in-memory implementation.
+
+### setUp / tearDown Pattern
+
+```dart
+late FakeAuthManager authFake;
+late FakeCacheManager cacheFake;
+late FakeVaultService vaultFake;
+late FakeLogManager logFake;
+
+setUp(() {
+  MagicApp.reset();
+  Magic.flush();
+
+  authFake = Auth.fake();         // In-memory auth, no storage
+  cacheFake = Cache.fake();       // In-memory cache, records operations
+  vaultFake = Vault.fake();       // In-memory secure storage, no platform channels
+  logFake = Log.fake();           // Captures log entries, no console output
+});
+
+tearDown(() {
+  Auth.unfake();
+  Cache.unfake();
+  Vault.unfake();
+  Log.unfake();
+});
+```
+
+### Auth.fake()
+
+```dart
+// Pre-authenticate with a user
+final fake = Auth.fake(user: myUser);
+expect(Auth.check(), isTrue);
+
+// Or start as guest
+final fake = Auth.fake();
+expect(Auth.guest, isTrue);
+
+// Assertions
+fake.assertLoggedIn();             // User is authenticated
+fake.assertLoggedOut();            // No user authenticated
+fake.assertLoginAttempted();       // At least one login() call
+fake.assertLoginCount(2);          // Exactly 2 login() calls
+```
+
+### Cache.fake()
+
+```dart
+final fake = Cache.fake();
+
+await Cache.put('users', ['Alice', 'Bob']);
+final value = Cache.get('users');
+
+// Assertions
+fake.assertHas('users');           // Key exists in store
+fake.assertMissing('missing_key'); // Key not in store
+fake.assertPut('users');           // put() was called with this key
+
+// Recorded operations: List<CacheRecord> ({operation, key, value})
+expect(fake.recorded.first.operation, 'put');
+```
+
+### Vault.fake()
+
+```dart
+// Pre-seed with initial values
+final fake = Vault.fake({'auth_token': 'seed-token'});
+
+await Vault.put('key', 'value');
+await Vault.delete('key');
+
+// Assertions
+fake.assertWritten('key');         // put() was called with this key
+fake.assertDeleted('key');         // delete() was called with this key
+fake.assertContains('key');        // Key currently exists in store
+fake.assertMissing('key');         // Key not in store
+
+// Recorded operations: List<VaultOperation> ({operation, key})
+expect(fake.recorded.first.operation, 'put');
+```
+
+### Log.fake()
+
+```dart
+final fake = Log.fake();
+
+Log.error('Payment failed', {'order': 42});
+Log.info('User logged in');
+
+// Assertions
+fake.assertLogged('error', 'Payment failed');  // Level + message match
+fake.assertLoggedError('Payment failed');       // Shorthand for error level
+fake.assertNothingLogged();                     // No entries at all
+fake.assertNothingLogged('warning');            // No entries at 'warning' level
+fake.assertLoggedCount(2);                      // Exactly 2 entries total
+
+// Entries: List<FakeLogEntry> ({level, message, context})
+expect(fake.entries[0].level, 'error');
+```
+
+### Reset Without Unfaking
+
+Use `fake.reset()` when reusing a fake across multiple tests in a group:
+
+```dart
+final logFake = Log.fake();
+
+test('first test', () {
+  Log.error('a');
+  logFake.assertLoggedCount(1);
+  logFake.reset(); // Clear entries — fake remains installed
+});
+
+test('second test', () {
+  Log.error('b');
+  logFake.assertLoggedCount(1); // Starts from zero
+});
+```
+
 ## Middleware Testing
 
 Middleware is tested by verifying whether it calls `next()` or halts the pipeline.

--- a/test/testing/facade_fake_integration_test.dart
+++ b/test/testing/facade_fake_integration_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+
+// ---------------------------------------------------------------------------
+// Test User Model
+// ---------------------------------------------------------------------------
+
+class _TestUser extends Model with HasTimestamps, Authenticatable {
+  @override
+  String get table => 'users';
+
+  @override
+  String get resource => 'users';
+
+  @override
+  List<String> get fillable => ['id', 'name', 'email'];
+
+  String? get name => getAttribute('name') as String?;
+  set name(String? value) => setAttribute('name', value);
+
+  String? get email => getAttribute('email') as String?;
+  set email(String? value) => setAttribute('email', value);
+}
+
+_TestUser _makeUser({
+  int id = 1,
+  String name = 'Alice',
+  String email = 'alice@example.com',
+}) {
+  final user = _TestUser();
+  user.fill({'id': id, 'name': name, 'email': email});
+  user.exists = true;
+  return user;
+}
+
+// ---------------------------------------------------------------------------
+// Integration Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('Facade Fake Integration', () {
+    setUp(() {
+      MagicApp.reset();
+      Magic.flush();
+    });
+
+    tearDown(() {
+      Http.unfake();
+      Auth.unfake();
+      Cache.unfake();
+      Vault.unfake();
+      Log.unfake();
+    });
+
+    test('all fakes work together without interference', () async {
+      // Setup all fakes
+      final httpFake = Http.fake({
+        'users/*': Http.response({'id': 1, 'name': 'Alice'}, 200),
+      });
+      final authFake = Auth.fake(user: _makeUser());
+      final cacheFake = Cache.fake();
+      final vaultFake = Vault.fake({'api_token': 'test-token'});
+      final logFake = Log.fake();
+
+      // Http fake responds correctly
+      final response = await Http.get('/users/1');
+      expect(response.successful, isTrue);
+
+      // Auth fake reports authenticated
+      expect(Auth.check(), isTrue);
+
+      // Cache fake stores and retrieves
+      await Cache.put('key', 'value');
+      expect(Cache.has('key'), isTrue);
+
+      // Vault fake returns pre-seeded value
+      final token = await Vault.get('api_token');
+      expect(token, equals('test-token'));
+
+      // Log fake captures message
+      Log.info('test message');
+
+      // Assert each fake recorded the correct interactions
+      httpFake.assertSent((r) => r.url.contains('users'));
+      authFake.assertLoggedIn();
+      cacheFake.assertHas('key');
+      vaultFake.assertContains('api_token');
+      logFake.assertLogged('info', 'test message');
+    });
+
+    test('fakes do not share state between test runs', () async {
+      // First run: put something in cache
+      Cache.fake();
+      await Cache.put('shared', 'first');
+      expect(Cache.has('shared'), isTrue);
+      Cache.unfake();
+
+      // Second fake instance starts fresh
+      final fresh = Cache.fake();
+      expect(Cache.has('shared'), isFalse);
+      fresh.assertMissing('shared');
+    });
+
+    test('unfake restores each service independently', () async {
+      // Fake everything
+      Http.fake();
+      Auth.fake();
+      Cache.fake();
+      Vault.fake();
+      Log.fake();
+
+      // Unfake Http — others should still work as fakes
+      Http.unfake();
+
+      // Auth fake is still active
+      expect(Auth.check(), isFalse); // unauthenticated fake still responds
+
+      // Cache fake is still active
+      await Cache.put('alive', true);
+      expect(Cache.has('alive'), isTrue);
+
+      // Vault fake is still active
+      await Vault.put('still', 'fake');
+      expect(await Vault.get('still'), equals('fake'));
+
+      // Log fake is still active
+      Log.warning('still faked');
+      expect(Magic.make<FakeLogManager>('log').entries, isNotEmpty);
+
+      Auth.unfake();
+      Cache.unfake();
+      Vault.unfake();
+      Log.unfake();
+    });
+
+    test('auth and cache fakes work together in login flow', () async {
+      final authFake = Auth.fake();
+      final cacheFake = Cache.fake();
+      final logFake = Log.fake();
+
+      // Simulate login
+      final user = _makeUser(id: 42, name: 'Bob');
+      await authFake.guard().login({'token': 'jwt-secret'}, user);
+
+      // Store session data in cache
+      await Cache.put('session_user_id', 42);
+      await Cache.put('session_name', 'Bob');
+
+      Log.info('User Bob logged in');
+
+      // Verify all recorded state
+      expect(Auth.check(), isTrue);
+      expect(Auth.user<_TestUser>()?.name, equals('Bob'));
+      expect(Cache.get('session_user_id'), equals(42));
+      authFake.assertLoginAttempted();
+      cacheFake.assertHas('session_user_id');
+      cacheFake.assertHas('session_name');
+      logFake.assertLogged('info', 'User Bob logged in');
+    });
+  });
+}

--- a/test/testing/fake_auth_manager_test.dart
+++ b/test/testing/fake_auth_manager_test.dart
@@ -1,0 +1,381 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+
+// ---------------------------------------------------------------------------
+// Test User Model
+// ---------------------------------------------------------------------------
+
+class _TestUser extends Model with HasTimestamps, Authenticatable {
+  @override
+  String get table => 'users';
+
+  @override
+  String get resource => 'users';
+
+  @override
+  List<String> get fillable => ['id', 'name', 'email'];
+
+  String? get name => getAttribute('name') as String?;
+  set name(String? value) => setAttribute('name', value);
+
+  String? get email => getAttribute('email') as String?;
+  set email(String? value) => setAttribute('email', value);
+}
+
+_TestUser _makeUser({
+  int id = 1,
+  String name = 'Alice',
+  String email = 'alice@example.com',
+}) {
+  final user = _TestUser();
+  user.fill({'id': id, 'name': name, 'email': email});
+  user.exists = true;
+  return user;
+}
+
+void main() {
+  setUp(() {
+    MagicApp.reset();
+    Magic.flush();
+  });
+
+  tearDown(() {
+    Auth.unfake();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 1. Unauthenticated state
+  // ---------------------------------------------------------------------------
+
+  group('unauthenticated state', () {
+    test('check returns false when no user is set', () {
+      final fake = FakeAuthManager();
+
+      expect(fake.guard().check(), isFalse);
+    });
+
+    test('guest returns true when no user is set', () {
+      final fake = FakeAuthManager();
+
+      expect(fake.guard().guest, isTrue);
+    });
+
+    test('user returns null when no user is set', () {
+      final fake = FakeAuthManager();
+
+      expect(fake.guard().user<_TestUser>(), isNull);
+    });
+
+    test('id returns null when no user is set', () {
+      final fake = FakeAuthManager();
+
+      expect(fake.guard().id(), isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. Authenticated state
+  // ---------------------------------------------------------------------------
+
+  group('authenticated state', () {
+    test('check returns true when user is provided', () {
+      final user = _makeUser();
+      final fake = FakeAuthManager(user: user);
+
+      expect(fake.guard().check(), isTrue);
+    });
+
+    test('guest returns false when user is provided', () {
+      final user = _makeUser();
+      final fake = FakeAuthManager(user: user);
+
+      expect(fake.guard().guest, isFalse);
+    });
+
+    test('user returns the provided model', () {
+      final user = _makeUser();
+      final fake = FakeAuthManager(user: user);
+
+      final result = fake.guard().user<_TestUser>();
+
+      expect(result, same(user));
+      expect(result?.name, equals('Alice'));
+    });
+
+    test('id returns the user auth identifier', () {
+      final user = _makeUser(id: 42);
+      final fake = FakeAuthManager(user: user);
+
+      expect(fake.guard().id(), equals(42));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. Login flow
+  // ---------------------------------------------------------------------------
+
+  group('login flow', () {
+    test('login sets user and makes check true', () async {
+      final fake = FakeAuthManager();
+      final user = _makeUser();
+
+      await fake.guard().login({'token': 'abc123'}, user);
+
+      expect(fake.guard().check(), isTrue);
+      expect(fake.guard().user<_TestUser>(), same(user));
+    });
+
+    test('login stores token from data map', () async {
+      final fake = FakeAuthManager();
+      final user = _makeUser();
+
+      await fake.guard().login({'token': 'secret-token'}, user);
+
+      expect(await fake.guard().hasToken(), isTrue);
+      expect(await fake.guard().getToken(), equals('secret-token'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. Logout flow
+  // ---------------------------------------------------------------------------
+
+  group('logout flow', () {
+    test('logout clears user and makes check false', () async {
+      final user = _makeUser();
+      final fake = FakeAuthManager(user: user);
+
+      await fake.guard().logout();
+
+      expect(fake.guard().check(), isFalse);
+      expect(fake.guard().user<_TestUser>(), isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. Token management
+  // ---------------------------------------------------------------------------
+
+  group('token management', () {
+    test('hasToken returns false when no token set', () async {
+      final fake = FakeAuthManager();
+
+      expect(await fake.guard().hasToken(), isFalse);
+    });
+
+    test('getToken returns null when no token set', () async {
+      final fake = FakeAuthManager();
+
+      expect(await fake.guard().getToken(), isNull);
+    });
+
+    test('login stores token and hasToken/getToken reflect it', () async {
+      final fake = FakeAuthManager();
+      final user = _makeUser();
+
+      await fake.guard().login({'token': 'my-jwt'}, user);
+
+      expect(await fake.guard().hasToken(), isTrue);
+      expect(await fake.guard().getToken(), equals('my-jwt'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 6. Assertions
+  // ---------------------------------------------------------------------------
+
+  group('assertions', () {
+    test('assertLoggedIn passes when user is set', () {
+      final fake = FakeAuthManager(user: _makeUser());
+
+      expect(() => fake.assertLoggedIn(), returnsNormally);
+    });
+
+    test('assertLoggedIn throws when no user', () {
+      final fake = FakeAuthManager();
+
+      expect(() => fake.assertLoggedIn(), throwsA(isA<AssertionError>()));
+    });
+
+    test('assertLoggedOut passes when no user', () {
+      final fake = FakeAuthManager();
+
+      expect(() => fake.assertLoggedOut(), returnsNormally);
+    });
+
+    test('assertLoggedOut throws when user is set', () {
+      final fake = FakeAuthManager(user: _makeUser());
+
+      expect(() => fake.assertLoggedOut(), throwsA(isA<AssertionError>()));
+    });
+
+    test('assertLoginAttempted passes after login', () async {
+      final fake = FakeAuthManager();
+
+      await fake.guard().login({'token': 'x'}, _makeUser());
+
+      expect(() => fake.assertLoginAttempted(), returnsNormally);
+    });
+
+    test('assertLoginAttempted throws when no login occurred', () {
+      final fake = FakeAuthManager();
+
+      expect(() => fake.assertLoginAttempted(), throwsA(isA<AssertionError>()));
+    });
+
+    test('assertLoginCount passes with correct count', () async {
+      final fake = FakeAuthManager();
+
+      await fake.guard().login({'token': 'a'}, _makeUser());
+      await fake.guard().login({'token': 'b'}, _makeUser(id: 2));
+
+      expect(() => fake.assertLoginCount(2), returnsNormally);
+    });
+
+    test('assertLoginCount throws with wrong count', () async {
+      final fake = FakeAuthManager();
+
+      await fake.guard().login({'token': 'a'}, _makeUser());
+
+      expect(() => fake.assertLoginCount(3), throwsA(isA<AssertionError>()));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 7. stateNotifier
+  // ---------------------------------------------------------------------------
+
+  group('stateNotifier', () {
+    test('bumps on login', () async {
+      final fake = FakeAuthManager();
+      final notifier = fake.guard().stateNotifier;
+      final initial = notifier.value;
+
+      await fake.guard().login({'token': 'x'}, _makeUser());
+
+      expect(notifier.value, equals(initial + 1));
+    });
+
+    test('bumps on logout', () async {
+      final fake = FakeAuthManager(user: _makeUser());
+      final notifier = fake.guard().stateNotifier;
+      final initial = notifier.value;
+
+      await fake.guard().logout();
+
+      expect(notifier.value, equals(initial + 1));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 8. Auth.fake() — facade integration
+  // ---------------------------------------------------------------------------
+
+  group('Auth.fake()', () {
+    test('returns a FakeAuthManager instance', () {
+      final fake = Auth.fake();
+
+      expect(fake, isA<FakeAuthManager>());
+    });
+
+    test('facade check routes through fake', () {
+      Auth.fake(user: _makeUser());
+
+      expect(Auth.check(), isTrue);
+    });
+
+    test('facade user returns the fake user', () {
+      final user = _makeUser();
+      Auth.fake(user: user);
+
+      expect(Auth.user<_TestUser>(), same(user));
+    });
+
+    test('facade login routes through fake', () async {
+      final fake = Auth.fake();
+      final user = _makeUser();
+
+      await Auth.login({'token': 'tok'}, user);
+
+      expect(Auth.check(), isTrue);
+      fake.assertLoginAttempted();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 9. Auth.unfake()
+  // ---------------------------------------------------------------------------
+
+  group('Auth.unfake()', () {
+    test('can be called without throwing', () {
+      Auth.fake();
+
+      expect(() => Auth.unfake(), returnsNormally);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 10. restore / refreshToken — no-op
+  // ---------------------------------------------------------------------------
+
+  group('restore and refreshToken', () {
+    test('restore completes without error', () async {
+      final fake = FakeAuthManager();
+
+      await expectLater(fake.guard().restore(), completes);
+    });
+
+    test('refreshToken returns false', () async {
+      final fake = FakeAuthManager();
+
+      expect(await fake.guard().refreshToken(), isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 11. setUser
+  // ---------------------------------------------------------------------------
+
+  group('setUser', () {
+    test('directly sets user without login', () {
+      final fake = FakeAuthManager();
+      final user = _makeUser();
+
+      fake.guard().setUser(user);
+
+      expect(fake.guard().check(), isTrue);
+      expect(fake.guard().user<_TestUser>(), same(user));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 12. reset
+  // ---------------------------------------------------------------------------
+
+  group('reset', () {
+    test('clears user, token, and login attempts', () async {
+      final fake = FakeAuthManager(user: _makeUser());
+
+      await fake.guard().login({'token': 'abc'}, _makeUser());
+      fake.reset();
+
+      expect(fake.guard().check(), isFalse);
+      expect(await fake.guard().hasToken(), isFalse);
+      expect(() => fake.assertLoginAttempted(), throwsA(isA<AssertionError>()));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 13. guard() always returns same fake guard regardless of name
+  // ---------------------------------------------------------------------------
+
+  group('guard resolution', () {
+    test('guard with any name returns the same fake guard', () {
+      final fake = FakeAuthManager(user: _makeUser());
+
+      expect(fake.guard().check(), isTrue);
+      expect(fake.guard('api').check(), isTrue);
+      expect(fake.guard('web').check(), isTrue);
+    });
+  });
+}

--- a/test/testing/fake_cache_manager_test.dart
+++ b/test/testing/fake_cache_manager_test.dart
@@ -1,0 +1,270 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+
+void main() {
+  setUp(() {
+    MagicApp.reset();
+    Magic.flush();
+  });
+
+  tearDown(() {
+    Cache.unfake();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 1. Basic operations
+  // ---------------------------------------------------------------------------
+
+  group('basic operations', () {
+    test('put stores a value and get retrieves it', () async {
+      final fake = FakeCacheManager();
+
+      await fake.put('user', 'alice');
+
+      expect(fake.get('user'), equals('alice'));
+    });
+
+    test('has returns true for existing key', () async {
+      final fake = FakeCacheManager();
+
+      await fake.put('token', 'abc123');
+
+      expect(fake.has('token'), isTrue);
+    });
+
+    test('has returns false for missing key', () {
+      final fake = FakeCacheManager();
+
+      expect(fake.has('missing'), isFalse);
+    });
+
+    test('forget removes a key', () async {
+      final fake = FakeCacheManager();
+
+      await fake.put('key', 'value');
+      await fake.forget('key');
+
+      expect(fake.has('key'), isFalse);
+    });
+
+    test('flush clears all keys', () async {
+      final fake = FakeCacheManager();
+
+      await fake.put('a', 1);
+      await fake.put('b', 2);
+      await fake.flush();
+
+      expect(fake.has('a'), isFalse);
+      expect(fake.has('b'), isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. Default values
+  // ---------------------------------------------------------------------------
+
+  group('default values', () {
+    test('get returns defaultValue when key is missing', () {
+      final fake = FakeCacheManager();
+
+      final result = fake.get('missing', defaultValue: 'fallback');
+
+      expect(result, equals('fallback'));
+    });
+
+    test('get returns null when key is missing and no default', () {
+      final fake = FakeCacheManager();
+
+      expect(fake.get('missing'), isNull);
+    });
+
+    test('get returns stored value even when defaultValue provided', () async {
+      final fake = FakeCacheManager();
+
+      await fake.put('key', 'real');
+
+      expect(fake.get('key', defaultValue: 'fallback'), equals('real'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. Assertions
+  // ---------------------------------------------------------------------------
+
+  group('assertions', () {
+    test('assertHas passes when key exists', () async {
+      final fake = FakeCacheManager();
+
+      await fake.put('token', 'secret');
+
+      expect(() => fake.assertHas('token'), returnsNormally);
+    });
+
+    test('assertHas throws AssertionError when key missing', () {
+      final fake = FakeCacheManager();
+
+      expect(() => fake.assertHas('missing'), throwsA(isA<AssertionError>()));
+    });
+
+    test('assertMissing passes when key does not exist', () {
+      final fake = FakeCacheManager();
+
+      expect(() => fake.assertMissing('ghost'), returnsNormally);
+    });
+
+    test('assertMissing throws AssertionError when key exists', () async {
+      final fake = FakeCacheManager();
+
+      await fake.put('present', 'value');
+
+      expect(
+        () => fake.assertMissing('present'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('assertPut passes when key was stored', () async {
+      final fake = FakeCacheManager();
+
+      await fake.put('user', 'bob');
+
+      expect(() => fake.assertPut('user'), returnsNormally);
+    });
+
+    test('assertPut throws AssertionError when key was never put', () {
+      final fake = FakeCacheManager();
+
+      expect(() => fake.assertPut('never'), throwsA(isA<AssertionError>()));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. Recording
+  // ---------------------------------------------------------------------------
+
+  group('recording', () {
+    test('records put operations', () async {
+      final fake = FakeCacheManager();
+
+      await fake.put('name', 'alice');
+
+      expect(fake.recorded, hasLength(1));
+      expect(fake.recorded.first.operation, equals('put'));
+      expect(fake.recorded.first.key, equals('name'));
+      expect(fake.recorded.first.value, equals('alice'));
+    });
+
+    test('records get operations', () async {
+      final fake = FakeCacheManager();
+
+      await fake.put('x', 10);
+      fake.get('x');
+
+      expect(fake.recorded.where((r) => r.operation == 'get'), hasLength(1));
+    });
+
+    test('records forget operations', () async {
+      final fake = FakeCacheManager();
+
+      await fake.put('key', 'val');
+      await fake.forget('key');
+
+      final forgets = fake.recorded.where((r) => r.operation == 'forget');
+      expect(forgets, hasLength(1));
+      expect(forgets.first.key, equals('key'));
+    });
+
+    test('records flush operations', () async {
+      final fake = FakeCacheManager();
+
+      await fake.flush();
+
+      expect(fake.recorded.any((r) => r.operation == 'flush'), isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. Cache.fake() — facade integration
+  // ---------------------------------------------------------------------------
+
+  group('Cache.fake()', () {
+    test('returns a FakeCacheManager instance', () {
+      final fake = Cache.fake();
+
+      expect(fake, isA<FakeCacheManager>());
+    });
+
+    test('facade put/get routes through fake', () async {
+      Cache.fake();
+
+      await Cache.put('greeting', 'hello');
+
+      expect(Cache.get('greeting'), equals('hello'));
+    });
+
+    test('facade has() routes through fake', () async {
+      Cache.fake();
+
+      await Cache.put('exists', true);
+
+      expect(Cache.has('exists'), isTrue);
+    });
+
+    test('facade forget() routes through fake', () async {
+      Cache.fake();
+
+      await Cache.put('bye', 'value');
+      await Cache.forget('bye');
+
+      expect(Cache.has('bye'), isFalse);
+    });
+
+    test('facade flush() routes through fake', () async {
+      Cache.fake();
+
+      await Cache.put('a', 1);
+      await Cache.put('b', 2);
+      await Cache.flush();
+
+      expect(Cache.has('a'), isFalse);
+      expect(Cache.has('b'), isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 6. Cache.unfake()
+  // ---------------------------------------------------------------------------
+
+  group('Cache.unfake()', () {
+    test('can be called without throwing', () {
+      Cache.fake();
+
+      expect(() => Cache.unfake(), returnsNormally);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 7. reset()
+  // ---------------------------------------------------------------------------
+
+  group('reset()', () {
+    test('clears the store', () async {
+      final fake = FakeCacheManager();
+
+      await fake.put('key', 'value');
+      fake.reset();
+
+      expect(fake.has('key'), isFalse);
+    });
+
+    test('clears recorded list', () async {
+      final fake = FakeCacheManager();
+
+      await fake.put('key', 'value');
+      fake.get('key');
+      fake.reset();
+
+      expect(fake.recorded, isEmpty);
+    });
+  });
+}

--- a/test/testing/fake_log_manager_test.dart
+++ b/test/testing/fake_log_manager_test.dart
@@ -1,0 +1,404 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+
+void main() {
+  setUp(() {
+    MagicApp.reset();
+    Magic.flush();
+  });
+
+  tearDown(() {
+    Log.unfake();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 1. Captures entries
+  // ---------------------------------------------------------------------------
+
+  group('captures entries', () {
+    test('log() captures level and message', () {
+      final fake = FakeLogManager();
+
+      fake.driver().log('info', 'Hello world');
+
+      expect(fake.entries, hasLength(1));
+      expect(fake.entries.first.level, equals('info'));
+      expect(fake.entries.first.message, equals('Hello world'));
+    });
+
+    test('info() is captured', () {
+      final fake = FakeLogManager();
+
+      fake.driver().info('Info message');
+
+      expect(fake.entries.first.level, equals('info'));
+      expect(fake.entries.first.message, equals('Info message'));
+    });
+
+    test('error() is captured', () {
+      final fake = FakeLogManager();
+
+      fake.driver().error('Error message');
+
+      expect(fake.entries.first.level, equals('error'));
+    });
+
+    test('warning() is captured', () {
+      final fake = FakeLogManager();
+
+      fake.driver().warning('Warning message');
+
+      expect(fake.entries.first.level, equals('warning'));
+    });
+
+    test('debug() is captured', () {
+      final fake = FakeLogManager();
+
+      fake.driver().debug('Debug message');
+
+      expect(fake.entries.first.level, equals('debug'));
+    });
+
+    test('multiple entries accumulate', () {
+      final fake = FakeLogManager();
+
+      fake.driver().info('First');
+      fake.driver().error('Second');
+      fake.driver().debug('Third');
+
+      expect(fake.entries, hasLength(3));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. Context preserved
+  // ---------------------------------------------------------------------------
+
+  group('context preserved', () {
+    test('context map is recorded', () {
+      final fake = FakeLogManager();
+
+      fake.driver().info('User action', {'id': 42, 'action': 'login'});
+
+      expect(fake.entries.first.context, isA<Map>());
+      expect((fake.entries.first.context as Map)['id'], equals(42));
+    });
+
+    test('null context is recorded as null', () {
+      final fake = FakeLogManager();
+
+      fake.driver().info('No context');
+
+      expect(fake.entries.first.context, isNull);
+    });
+
+    test('string context is recorded', () {
+      final fake = FakeLogManager();
+
+      fake.driver().error('Failed', 'some string context');
+
+      expect(fake.entries.first.context, equals('some string context'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. All RFC 5424 levels
+  // ---------------------------------------------------------------------------
+
+  group('all RFC 5424 levels captured', () {
+    test('emergency level is captured', () {
+      final fake = FakeLogManager();
+      fake.driver().emergency('System down');
+      expect(fake.entries.first.level, equals('emergency'));
+    });
+
+    test('alert level is captured', () {
+      final fake = FakeLogManager();
+      fake.driver().alert('Immediate action');
+      expect(fake.entries.first.level, equals('alert'));
+    });
+
+    test('critical level is captured', () {
+      final fake = FakeLogManager();
+      fake.driver().critical('Critical condition');
+      expect(fake.entries.first.level, equals('critical'));
+    });
+
+    test('error level is captured', () {
+      final fake = FakeLogManager();
+      fake.driver().error('Runtime error');
+      expect(fake.entries.first.level, equals('error'));
+    });
+
+    test('warning level is captured', () {
+      final fake = FakeLogManager();
+      fake.driver().warning('Deprecated usage');
+      expect(fake.entries.first.level, equals('warning'));
+    });
+
+    test('notice level is captured', () {
+      final fake = FakeLogManager();
+      fake.driver().notice('Significant event');
+      expect(fake.entries.first.level, equals('notice'));
+    });
+
+    test('info level is captured', () {
+      final fake = FakeLogManager();
+      fake.driver().info('Interesting event');
+      expect(fake.entries.first.level, equals('info'));
+    });
+
+    test('debug level is captured', () {
+      final fake = FakeLogManager();
+      fake.driver().debug('Debug data');
+      expect(fake.entries.first.level, equals('debug'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. assertLogged
+  // ---------------------------------------------------------------------------
+
+  group('assertLogged', () {
+    test('passes when matching level and message exist', () {
+      final fake = FakeLogManager();
+
+      fake.driver().error('Payment failed');
+
+      expect(
+        () => fake.assertLogged('error', 'Payment failed'),
+        returnsNormally,
+      );
+    });
+
+    test('throws AssertionError when level does not match', () {
+      final fake = FakeLogManager();
+
+      fake.driver().info('Payment failed');
+
+      expect(
+        () => fake.assertLogged('error', 'Payment failed'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('throws AssertionError when message does not match', () {
+      final fake = FakeLogManager();
+
+      fake.driver().error('Something else');
+
+      expect(
+        () => fake.assertLogged('error', 'Payment failed'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('throws AssertionError when entries is empty', () {
+      final fake = FakeLogManager();
+
+      expect(
+        () => fake.assertLogged('error', 'Any message'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. assertLoggedError shorthand
+  // ---------------------------------------------------------------------------
+
+  group('assertLoggedError', () {
+    test('passes when error message was logged', () {
+      final fake = FakeLogManager();
+
+      fake.driver().error('Database connection failed');
+
+      expect(
+        () => fake.assertLoggedError('Database connection failed'),
+        returnsNormally,
+      );
+    });
+
+    test('throws AssertionError when error message was not logged', () {
+      final fake = FakeLogManager();
+
+      fake.driver().info('Database connection failed');
+
+      expect(
+        () => fake.assertLoggedError('Database connection failed'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 6. assertNothingLogged (no level filter)
+  // ---------------------------------------------------------------------------
+
+  group('assertNothingLogged', () {
+    test('passes when no entries exist', () {
+      final fake = FakeLogManager();
+
+      expect(() => fake.assertNothingLogged(), returnsNormally);
+    });
+
+    test('throws AssertionError when entries exist', () {
+      final fake = FakeLogManager();
+
+      fake.driver().info('Something');
+
+      expect(() => fake.assertNothingLogged(), throwsA(isA<AssertionError>()));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 7. assertNothingLogged with level filter
+  // ---------------------------------------------------------------------------
+
+  group('assertNothingLogged with level', () {
+    test('passes when no entries at specified level', () {
+      final fake = FakeLogManager();
+
+      fake.driver().info('Info message');
+
+      expect(() => fake.assertNothingLogged('error'), returnsNormally);
+    });
+
+    test('throws AssertionError when entries exist at specified level', () {
+      final fake = FakeLogManager();
+
+      fake.driver().error('An error');
+
+      expect(
+        () => fake.assertNothingLogged('error'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 8. assertLoggedCount
+  // ---------------------------------------------------------------------------
+
+  group('assertLoggedCount', () {
+    test('passes when count matches exactly', () {
+      final fake = FakeLogManager();
+
+      fake.driver().info('One');
+      fake.driver().error('Two');
+      fake.driver().debug('Three');
+
+      expect(() => fake.assertLoggedCount(3), returnsNormally);
+    });
+
+    test('throws AssertionError when count does not match', () {
+      final fake = FakeLogManager();
+
+      fake.driver().info('One');
+
+      expect(() => fake.assertLoggedCount(2), throwsA(isA<AssertionError>()));
+    });
+
+    test('passes with zero when nothing was logged', () {
+      final fake = FakeLogManager();
+
+      expect(() => fake.assertLoggedCount(0), returnsNormally);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 9. reset()
+  // ---------------------------------------------------------------------------
+
+  group('reset()', () {
+    test('clears all entries', () {
+      final fake = FakeLogManager();
+
+      fake.driver().info('Entry one');
+      fake.driver().error('Entry two');
+      fake.reset();
+
+      expect(fake.entries, isEmpty);
+    });
+
+    test('after reset assertNothingLogged passes', () {
+      final fake = FakeLogManager();
+
+      fake.driver().error('Something');
+      fake.reset();
+
+      expect(() => fake.assertNothingLogged(), returnsNormally);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 10. Log.fake() — facade integration
+  // ---------------------------------------------------------------------------
+
+  group('Log.fake()', () {
+    test('returns a FakeLogManager instance', () {
+      final fake = Log.fake();
+
+      expect(fake, isA<FakeLogManager>());
+    });
+
+    test('Log.info() routes through the fake', () {
+      final fake = Log.fake();
+
+      Log.info('User signed in');
+
+      expect(fake.entries, hasLength(1));
+      expect(fake.entries.first.level, equals('info'));
+      expect(fake.entries.first.message, equals('User signed in'));
+    });
+
+    test('Log.error() is captured by fake', () {
+      final fake = Log.fake();
+
+      Log.error('Unhandled exception');
+
+      fake.assertLoggedError('Unhandled exception');
+    });
+
+    test('Log.warning() is captured by fake', () {
+      final fake = Log.fake();
+
+      Log.warning('Deprecated API used');
+
+      expect(fake.entries.first.level, equals('warning'));
+    });
+
+    test('Log.debug() is captured by fake', () {
+      final fake = Log.fake();
+
+      Log.debug('Query executed');
+
+      expect(fake.entries.first.level, equals('debug'));
+    });
+
+    test('multiple facade calls accumulate entries', () {
+      final fake = Log.fake();
+
+      Log.info('First');
+      Log.error('Second');
+
+      fake.assertLoggedCount(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 11. Log.unfake()
+  // ---------------------------------------------------------------------------
+
+  group('Log.unfake()', () {
+    test('can be called without throwing', () {
+      Log.fake();
+
+      expect(() => Log.unfake(), returnsNormally);
+    });
+
+    test('can be called when not faked without throwing', () {
+      expect(() => Log.unfake(), returnsNormally);
+    });
+  });
+}

--- a/test/testing/fake_vault_service_test.dart
+++ b/test/testing/fake_vault_service_test.dart
@@ -1,0 +1,212 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+
+void main() {
+  setUp(() {
+    MagicApp.reset();
+    Magic.flush();
+  });
+
+  group('FakeVaultService - basic operations', () {
+    late FakeVaultService vault;
+
+    setUp(() {
+      vault = FakeVaultService();
+    });
+
+    test('put stores a value', () async {
+      await vault.put('key', 'value');
+      expect(await vault.get('key'), equals('value'));
+    });
+
+    test('get returns null for missing key', () async {
+      expect(await vault.get('missing'), isNull);
+    });
+
+    test('remove deletes a stored value', () async {
+      await vault.put('key', 'value');
+      await vault.remove('key');
+      expect(await vault.get('key'), isNull);
+    });
+
+    test('flush clears all stored values', () async {
+      await vault.put('key1', 'val1');
+      await vault.put('key2', 'val2');
+      await vault.flush();
+      expect(await vault.get('key1'), isNull);
+      expect(await vault.get('key2'), isNull);
+    });
+  });
+
+  group('FakeVaultService - initial values', () {
+    test('constructor pre-populates store from initial values', () async {
+      final vault = FakeVaultService({'token': 'abc123', 'user_id': '42'});
+      expect(await vault.get('token'), equals('abc123'));
+      expect(await vault.get('user_id'), equals('42'));
+    });
+
+    test('initial values can be overwritten', () async {
+      final vault = FakeVaultService({'token': 'old'});
+      await vault.put('token', 'new');
+      expect(await vault.get('token'), equals('new'));
+    });
+  });
+
+  group('FakeVaultService - assertions', () {
+    late FakeVaultService vault;
+
+    setUp(() {
+      vault = FakeVaultService();
+    });
+
+    test('assertWritten passes when key was written', () async {
+      await vault.put('token', 'abc');
+      expect(() => vault.assertWritten('token'), returnsNormally);
+    });
+
+    test('assertWritten throws when key was not written', () {
+      expect(
+        () => vault.assertWritten('missing'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('assertDeleted passes when key was deleted', () async {
+      await vault.put('key', 'val');
+      await vault.remove('key');
+      expect(() => vault.assertDeleted('key'), returnsNormally);
+    });
+
+    test('assertDeleted throws when key was not deleted', () {
+      expect(
+        () => vault.assertDeleted('missing'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('assertContains passes when key exists in store', () async {
+      await vault.put('key', 'val');
+      expect(() => vault.assertContains('key'), returnsNormally);
+    });
+
+    test('assertContains throws when key is missing from store', () {
+      expect(
+        () => vault.assertContains('missing'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('assertMissing passes when key is not in store', () {
+      expect(() => vault.assertMissing('gone'), returnsNormally);
+    });
+
+    test('assertMissing throws when key exists in store', () async {
+      await vault.put('key', 'val');
+      expect(() => vault.assertMissing('key'), throwsA(isA<AssertionError>()));
+    });
+  });
+
+  group('FakeVaultService - recording', () {
+    late FakeVaultService vault;
+
+    setUp(() {
+      vault = FakeVaultService();
+    });
+
+    test('records put operations', () async {
+      await vault.put('token', 'abc');
+      expect(vault.recorded, hasLength(1));
+      expect(vault.recorded.first.operation, equals('put'));
+      expect(vault.recorded.first.key, equals('token'));
+    });
+
+    test('records get operations', () async {
+      await vault.get('token');
+      expect(vault.recorded, hasLength(1));
+      expect(vault.recorded.first.operation, equals('get'));
+      expect(vault.recorded.first.key, equals('token'));
+    });
+
+    test('records remove operations', () async {
+      await vault.remove('token');
+      expect(vault.recorded, hasLength(1));
+      expect(vault.recorded.first.operation, equals('remove'));
+      expect(vault.recorded.first.key, equals('token'));
+    });
+
+    test('records flush operation', () async {
+      await vault.flush();
+      expect(vault.recorded, hasLength(1));
+      expect(vault.recorded.first.operation, equals('flush'));
+    });
+
+    test('records multiple operations in order', () async {
+      await vault.put('a', '1');
+      await vault.get('a');
+      await vault.remove('a');
+      expect(vault.recorded, hasLength(3));
+      expect(vault.recorded[0].operation, equals('put'));
+      expect(vault.recorded[1].operation, equals('get'));
+      expect(vault.recorded[2].operation, equals('remove'));
+    });
+  });
+
+  group('FakeVaultService - reset()', () {
+    test('clears store and recorded list', () async {
+      final vault = FakeVaultService();
+      await vault.put('key', 'val');
+      await vault.get('key');
+      vault.reset();
+      expect(await vault.get('key'), isNull);
+      // recorded after reset only has the get from this call
+      expect(vault.recorded, hasLength(1));
+    });
+
+    test('store is empty after reset', () async {
+      final vault = FakeVaultService({'existing': 'val'});
+      vault.reset();
+      expect(await vault.get('existing'), isNull);
+    });
+  });
+
+  group('Vault.fake() - facade integration', () {
+    test('fake() returns FakeVaultService', () {
+      final fake = Vault.fake();
+      expect(fake.runtimeType.toString(), equals('FakeVaultService'));
+    });
+
+    test('fake() registers service in container', () async {
+      final fake = Vault.fake();
+      await Vault.put('key', 'value');
+      expect(await fake.get('key'), equals('value'));
+    });
+
+    test('fake() with initial values pre-populates store', () async {
+      Vault.fake({'secret': 'token123'});
+      expect(await Vault.get('secret'), equals('token123'));
+    });
+
+    test('Vault facade calls are delegated to fake', () async {
+      final fake = Vault.fake();
+      await Vault.put('x', '1');
+      await Vault.get('x');
+      await Vault.delete('x');
+      expect(fake.recorded, hasLength(3));
+    });
+  });
+
+  group('Vault.unfake()', () {
+    test('unfake() removes fake from container', () {
+      Magic.app.singleton('vault', () => MagicVaultService.forTesting());
+      Vault.fake();
+      Vault.unfake();
+      // After unfake, the container resolves from the singleton binding (not a fake)
+      final resolved = Magic.make<MagicVaultService>('vault');
+      expect(resolved, isA<MagicVaultService>());
+      expect(
+        resolved.runtimeType.toString(),
+        isNot(equals('FakeVaultService')),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `Auth.fake()`, `Cache.fake()`, `Vault.fake()`, `Log.fake()` following the `Http.fake()` pattern from #18
- Each facade gets `fake()`/`unfake()` static methods that swap IoC bindings with in-memory test doubles
- Refactors Auth facade from direct singleton to IoC resolution (`Magic.make<AuthManager>('auth')`)
- Adds `AuthManager.forTesting()` and `MagicVaultService.forTesting()` constructors for subclassing
- 130 new tests (649 total), zero analyzer warnings

Closes #19

## Test plan

- [x] `flutter test` — 649/649 passing
- [x] `dart analyze` — zero warnings
- [x] All 4 fakes work independently (unit tests per fake)
- [x] All 5 fakes coexist in integration test (`facade_fake_integration_test.dart`)
- [x] Auth facade IoC refactor has no regression (existing 26 auth tests pass)
- [x] Code review: 37/37 plan criteria APPROVED