### PR TITLE
feat(http): MagicStateMixin fetchList/fetchOne (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### ✨ Features
+- `fetchList()` / `fetchOne()` on `MagicStateMixin` — auto state management for HTTP fetches (#20)
 - **Http Faking**: `Http.fake()` enables Laravel-style HTTP faking for testing. Swap the real network driver with a `FakeNetworkDriver` that records requests and returns stubbed responses. Supports URL pattern stubs, callback stubs, and assertion methods (`assertSent`, `assertNotSent`, `assertNothingSent`, `assertSentCount`). (#18)
 - **Facade Faking**: `Auth.fake()`, `Cache.fake()`, `Vault.fake()`, `Log.fake()` — Laravel-style facade faking for testing. Swap real service implementations with in-memory fakes that record operations and expose assertion helpers. (#19)
 

--- a/doc/basics/controllers.md
+++ b/doc/basics/controllers.md
@@ -129,6 +129,86 @@ class UserController extends MagicController
 | `isEmpty` | bool | Empty/no data |
 | `rxState` | T? | The current data |
 
+<a name="fetch-helpers"></a>
+### Fetch Helpers
+
+`MagicStateMixin` ships two convenience methods that handle the full loading → success/error/empty cycle without boilerplate. Both delegate to `Http.get()` internally.
+
+#### `fetchList<E>`
+
+Fetch a paginated or collection endpoint. The response body must contain a JSON array under `dataKey` (default: `'data'`).
+
+```dart
+Future<void> fetchList<E>(
+  String url,
+  E Function(Map<String, dynamic>) fromMap, {
+  String dataKey = 'data',
+  Map<String, dynamic>? query,
+  Map<String, String>? headers,
+})
+```
+
+```dart
+class ProjectController extends MagicController
+    with MagicStateMixin<List<Project>> {
+
+  static ProjectController get instance =>
+      Magic.findOrPut(ProjectController.new);
+
+  Future<void> loadProjects(String teamId) =>
+      fetchList('teams/$teamId/projects', Project.fromMap);
+
+  // With query parameters
+  Future<void> search(String q) =>
+      fetchList('projects', Project.fromMap, query: {'q': q});
+}
+```
+
+State transitions:
+
+| Condition | Resulting State |
+|-----------|----------------|
+| Request fails (4xx/5xx) | `isError` with `response.errorMessage` |
+| `dataKey` list is null or empty | `isEmpty` |
+| List has items | `isSuccess` with `List<E>` cast to `T` |
+
+#### `fetchOne`
+
+Fetch a single resource. The response body must contain the resource object under `dataKey` (default: `'data'`).
+
+```dart
+Future<void> fetchOne(
+  String url,
+  T Function(Map<String, dynamic>) fromMap, {
+  String dataKey = 'data',
+  Map<String, dynamic>? query,
+  Map<String, String>? headers,
+})
+```
+
+```dart
+class ProjectDetailController extends MagicController
+    with MagicStateMixin<Project> {
+
+  static ProjectDetailController get instance =>
+      Magic.findOrPut(ProjectDetailController.new);
+
+  Future<void> loadProject(String id) =>
+      fetchOne('projects/$id', Project.fromMap);
+}
+```
+
+State transitions:
+
+| Condition | Resulting State |
+|-----------|----------------|
+| Request fails (4xx/5xx) | `isError` with `response.errorMessage` |
+| `dataKey` value is null | `isError` with `'Resource not found'` |
+| Data present | `isSuccess` with parsed `T` |
+
+> [!TIP]
+> Both helpers accept optional `query` and `headers` parameters, forwarded directly to `Http.get()`. Use `query` for pagination or filtering parameters.
+
 <a name="rendering-state"></a>
 ### Rendering State
 

--- a/doc/testing/http-tests.md
+++ b/doc/testing/http-tests.md
@@ -310,6 +310,133 @@ void main() {
 }
 ```
 
+## Testing fetchList and fetchOne
+
+Controllers that use `fetchList()` or `fetchOne()` from `MagicStateMixin` can be tested with `Http.fake()` the same way as any other HTTP call. Stub the URL the helper will request, then assert on the resulting controller state.
+
+### fetchList
+
+```dart
+// lib/controllers/project_controller.dart
+class ProjectController extends MagicController
+    with MagicStateMixin<List<Project>> {
+  Future<void> loadProjects(String teamId) =>
+      fetchList('teams/$teamId/projects', Project.fromMap);
+}
+
+// test/http/project_controller_test.dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+
+void main() {
+  group('ProjectController.fetchList', () {
+    late ProjectController controller;
+    late FakeNetworkDriver fake;
+
+    setUp(() {
+      MagicApp.reset();
+      Magic.flush();
+
+      controller = ProjectController();
+      Magic.put<ProjectController>(controller);
+
+      fake = Http.fake({
+        'teams/*/projects': Http.response({
+          'data': [
+            {'id': 1, 'name': 'Project A'},
+            {'id': 2, 'name': 'Project B'},
+          ],
+        }, 200),
+      });
+    });
+
+    tearDown(() => Http.unfake());
+
+    test('sets success state with parsed list', () async {
+      await controller.loadProjects('team-1');
+
+      expect(controller.isSuccess, isTrue);
+      expect(controller.rxState?.length, 2);
+      expect(controller.rxState?.first.name, 'Project A');
+      fake.assertSent((r) => r.url.contains('teams/team-1/projects'));
+    });
+
+    test('sets empty state when data list is empty', () async {
+      fake.stub('teams/*/projects', Http.response({'data': []}, 200));
+
+      await controller.loadProjects('team-1');
+
+      expect(controller.isEmpty, isTrue);
+    });
+
+    test('sets error state on failed response', () async {
+      fake.stub(
+        'teams/*/projects',
+        Http.response({'message': 'Unauthorized'}, 401),
+      );
+
+      await controller.loadProjects('team-1');
+
+      expect(controller.isError, isTrue);
+    });
+  });
+}
+```
+
+### fetchOne
+
+```dart
+// lib/controllers/project_detail_controller.dart
+class ProjectDetailController extends MagicController
+    with MagicStateMixin<Project> {
+  Future<void> loadProject(String id) =>
+      fetchOne('projects/$id', Project.fromMap);
+}
+
+// test/http/project_detail_controller_test.dart
+void main() {
+  group('ProjectDetailController.fetchOne', () {
+    late ProjectDetailController controller;
+    late FakeNetworkDriver fake;
+
+    setUp(() {
+      MagicApp.reset();
+      Magic.flush();
+
+      controller = ProjectDetailController();
+      Magic.put<ProjectDetailController>(controller);
+
+      fake = Http.fake({
+        'projects/*': Http.response({
+          'data': {'id': 1, 'name': 'Project A'},
+        }, 200),
+      });
+    });
+
+    tearDown(() => Http.unfake());
+
+    test('sets success state with parsed model', () async {
+      await controller.loadProject('1');
+
+      expect(controller.isSuccess, isTrue);
+      expect(controller.rxState?.name, 'Project A');
+      fake.assertSent((r) => r.url.contains('projects/1'));
+    });
+
+    test('sets error state when data key is absent', () async {
+      fake.stub('projects/*', Http.response({'meta': {}}, 200));
+
+      await controller.loadProject('1');
+
+      expect(controller.isError, isTrue);
+    });
+  });
+}
+```
+
+> [!TIP]
+> Use `fake.stub()` inside individual tests to override the default stub registered in `setUp`. This keeps the happy path in `setUp` and edge cases inline.
+
 ## See Also
 
 - [Facade Testing](facades.md) — `Auth.fake()`, `Cache.fake()`, `Vault.fake()`, `Log.fake()`

--- a/lib/src/http/magic_controller.dart
+++ b/lib/src/http/magic_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:fluttersdk_wind/fluttersdk_wind.dart';
 
+import '../facades/http.dart';
 import 'rx_status.dart';
 
 /// The Base Controller for Magic MVC.
@@ -180,6 +181,74 @@ mixin MagicStateMixin<T> on MagicController {
   /// ```
   void setEmpty() {
     setState(null, status: const RxStatus.empty());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Fetch Helpers
+  // ---------------------------------------------------------------------------
+
+  /// Fetch a list of resources and auto-manage loading/success/error/empty states.
+  ///
+  /// ```dart
+  /// await fetchList<User>('api/users', User.fromMap);
+  /// ```
+  Future<void> fetchList<E>(
+    String url,
+    E Function(Map<String, dynamic>) fromMap, {
+    String dataKey = 'data',
+    Map<String, dynamic>? query,
+    Map<String, String>? headers,
+  }) async {
+    setLoading();
+    final response = await Http.get(url, query: query, headers: headers);
+
+    if (response.failed) {
+      setError(response.errorMessage ?? 'Failed to load');
+      return;
+    }
+
+    final rawList = response.data[dataKey] as List?;
+
+    if (rawList == null || rawList.isEmpty) {
+      setEmpty();
+      return;
+    }
+
+    final items = rawList
+        .map((e) => fromMap(e as Map<String, dynamic>))
+        .toList();
+
+    setSuccess(items as T);
+  }
+
+  /// Fetch a single resource and auto-manage loading/success/error states.
+  ///
+  /// ```dart
+  /// await fetchOne('api/users/1', User.fromMap);
+  /// ```
+  Future<void> fetchOne(
+    String url,
+    T Function(Map<String, dynamic>) fromMap, {
+    String dataKey = 'data',
+    Map<String, dynamic>? query,
+    Map<String, String>? headers,
+  }) async {
+    setLoading();
+    final response = await Http.get(url, query: query, headers: headers);
+
+    if (response.failed) {
+      setError(response.errorMessage ?? 'Failed to load');
+      return;
+    }
+
+    final data = response.data[dataKey];
+
+    if (data == null) {
+      setError('Resource not found');
+      return;
+    }
+
+    setSuccess(fromMap(data as Map<String, dynamic>));
   }
 
   /// Render UI based on current status.

--- a/skills/magic-framework/references/http-network.md
+++ b/skills/magic-framework/references/http-network.md
@@ -344,6 +344,83 @@ The mixin provides:
 - `hasError(String field)`: Check if a field has errors
 - `fieldError(String field)`: Get error message for a field
 
+## MagicStateMixin Fetch Helpers
+
+`MagicStateMixin<T>` ships `fetchList()` and `fetchOne()` to eliminate boilerplate loading/success/error state transitions for HTTP fetches.
+
+### `fetchList<E>(url, fromMap, {dataKey, query, headers})`
+
+Fetches a JSON array under `dataKey` (default `'data'`) and calls `setSuccess(items)`, `setEmpty()`, or `setError(message)` automatically.
+
+```dart
+class ProjectController extends MagicController
+    with MagicStateMixin<List<Project>> {
+  Future<void> loadProjects(String teamId) =>
+      fetchList('teams/$teamId/projects', Project.fromMap);
+}
+```
+
+Signature:
+```dart
+Future<void> fetchList<E>(
+  String url,
+  E Function(Map<String, dynamic>) fromMap, {
+  String dataKey = 'data',
+  Map<String, dynamic>? query,
+  Map<String, String>? headers,
+})
+```
+
+Note: `E` is the element type of the list. The resulting `List<E>` is cast to `T` (the mixin's type parameter), so declare the controller as `MagicStateMixin<List<E>>`.
+
+### `fetchOne(url, fromMap, {dataKey, query, headers})`
+
+Fetches a single object under `dataKey` (default `'data'`) and calls `setSuccess(item)` or `setError(message)` automatically.
+
+```dart
+class ProjectDetailController extends MagicController
+    with MagicStateMixin<Project> {
+  Future<void> loadProject(String id) =>
+      fetchOne('projects/$id', Project.fromMap);
+}
+```
+
+Signature:
+```dart
+Future<void> fetchOne(
+  String url,
+  T Function(Map<String, dynamic>) fromMap, {
+  String dataKey = 'data',
+  Map<String, dynamic>? query,
+  Map<String, String>? headers,
+})
+```
+
+State transition table (both helpers):
+
+| Condition | State |
+|-----------|-------|
+| Response `failed` (>= 400) | `setError(response.errorMessage ?? 'Failed to load')` |
+| `fetchList`: list null or empty | `setEmpty()` |
+| `fetchOne`: `dataKey` value null | `setError('Resource not found')` |
+| Data present | `setSuccess(parsed)` |
+
+Testing with `Http.fake()`:
+```dart
+Http.fake({
+  'teams/*/projects': Http.response({
+    'data': [
+      {'id': 1, 'name': 'Project A'},
+    ],
+  }, 200),
+});
+
+await controller.loadProjects('team-1');
+
+expect(controller.isSuccess, isTrue);
+expect(controller.rxState?.length, 1);
+```
+
 ## Common Patterns
 
 ### Error Handling with Network Requests

--- a/test/http/magic_controller_test.dart
+++ b/test/http/magic_controller_test.dart
@@ -8,6 +8,22 @@ class TestController extends MagicController with MagicStateMixin<String> {
   }
 }
 
+// For fetchList tests — T is List<Map<String, dynamic>>
+class _ListController extends MagicController
+    with MagicStateMixin<List<Map<String, dynamic>>> {
+  _ListController() {
+    onInit();
+  }
+}
+
+// For fetchOne tests — T is Map<String, dynamic>
+class _SingleController extends MagicController
+    with MagicStateMixin<Map<String, dynamic>> {
+  _SingleController() {
+    onInit();
+  }
+}
+
 void main() {
   group('MagicStateMixin', () {
     late TestController controller;
@@ -88,6 +104,230 @@ void main() {
       expect(controller.isDisposed, isFalse);
       controller.dispose();
       expect(controller.isDisposed, isTrue);
+    });
+  });
+
+  group('MagicStateMixin.fetchList', () {
+    late _ListController controller;
+
+    setUp(() {
+      MagicApp.reset();
+      Magic.flush();
+      controller = _ListController();
+    });
+
+    tearDown(() {
+      Http.unfake();
+    });
+
+    test('success: sets isSuccess and rxState with mapped list', () async {
+      Http.fake({
+        'items': Http.response({
+          'data': [
+            {'id': 1, 'name': 'A'},
+            {'id': 2, 'name': 'B'},
+          ],
+        }, 200),
+      });
+
+      await controller.fetchList<Map<String, dynamic>>('items', (m) => m);
+
+      expect(controller.isSuccess, isTrue);
+      expect(controller.rxState, isNotNull);
+      expect(controller.rxState!.length, equals(2));
+    });
+
+    test('empty list: sets isEmpty when data array is empty', () async {
+      Http.fake({
+        'items': Http.response({'data': []}, 200),
+      });
+
+      await controller.fetchList<Map<String, dynamic>>('items', (m) => m);
+
+      expect(controller.isEmpty, isTrue);
+    });
+
+    test('null data key: sets isEmpty when data value is null', () async {
+      Http.fake({
+        'items': Http.response({'data': null}, 200),
+      });
+
+      await controller.fetchList<Map<String, dynamic>>('items', (m) => m);
+
+      expect(controller.isEmpty, isTrue);
+    });
+
+    test('error response: sets isError with server message', () async {
+      Http.fake({
+        'items': Http.response({'message': 'Server error'}, 500),
+      });
+
+      await controller.fetchList<Map<String, dynamic>>('items', (m) => m);
+
+      expect(controller.isError, isTrue);
+      expect(controller.rxStatus.message, contains('Server error'));
+    });
+
+    test('custom dataKey: reads list from specified key', () async {
+      Http.fake({
+        'items': Http.response({
+          'results': [
+            {'id': 1},
+          ],
+        }, 200),
+      });
+
+      await controller.fetchList<Map<String, dynamic>>(
+        'items',
+        (m) => m,
+        dataKey: 'results',
+      );
+
+      expect(controller.isSuccess, isTrue);
+      expect(controller.rxState!.length, equals(1));
+    });
+
+    test('query params: forwards query parameters to the request', () async {
+      Http.fake({
+        'items': (request) {
+          expect(request.queryParameters['page'], equals('2'));
+          expect(request.queryParameters['limit'], equals('10'));
+          return Http.response({'data': []}, 200);
+        },
+      });
+
+      await controller.fetchList<Map<String, dynamic>>(
+        'items',
+        (m) => m,
+        query: {'page': '2', 'limit': '10'},
+      );
+    });
+
+    test('headers: forwards custom headers to the request', () async {
+      Http.fake({
+        'items': (request) {
+          expect(request.headers['X-Custom-Header'], equals('test-value'));
+          return Http.response({'data': []}, 200);
+        },
+      });
+
+      await controller.fetchList<Map<String, dynamic>>(
+        'items',
+        (m) => m,
+        headers: {'X-Custom-Header': 'test-value'},
+      );
+    });
+
+    test('loading state: completes with success after loading phase', () async {
+      Http.fake({
+        'items': Http.response({
+          'data': [
+            {'id': 1},
+          ],
+        }, 200),
+      });
+
+      await controller.fetchList<Map<String, dynamic>>('items', (m) => m);
+
+      // After awaiting, final state is success (went through loading internally)
+      expect(controller.isSuccess, isTrue);
+      expect(controller.isLoading, isFalse);
+    });
+  });
+
+  group('MagicStateMixin.fetchOne', () {
+    late _SingleController controller;
+
+    setUp(() {
+      MagicApp.reset();
+      Magic.flush();
+      controller = _SingleController();
+    });
+
+    tearDown(() {
+      Http.unfake();
+    });
+
+    test('success: sets isSuccess and rxState with mapped object', () async {
+      Http.fake({
+        'user': Http.response({
+          'data': {'id': 1, 'name': 'Alice'},
+        }, 200),
+      });
+
+      await controller.fetchOne('user', (m) => m);
+
+      expect(controller.isSuccess, isTrue);
+      expect(controller.rxState, isNotNull);
+      expect(controller.rxState!['id'], equals(1));
+      expect(controller.rxState!['name'], equals('Alice'));
+    });
+
+    test('null data: sets isError with "Resource not found" message', () async {
+      Http.fake({
+        'user': Http.response({'data': null}, 200),
+      });
+
+      await controller.fetchOne('user', (m) => m);
+
+      expect(controller.isError, isTrue);
+      expect(controller.rxStatus.message, equals('Resource not found'));
+    });
+
+    test('error response: sets isError with server message', () async {
+      Http.fake({
+        'user': Http.response({'message': 'Not found'}, 404),
+      });
+
+      await controller.fetchOne('user', (m) => m);
+
+      expect(controller.isError, isTrue);
+      expect(controller.rxStatus.message, contains('Not found'));
+    });
+
+    test('custom dataKey: reads object from specified key', () async {
+      Http.fake({
+        'user': Http.response({
+          'item': {'id': 1},
+        }, 200),
+      });
+
+      await controller.fetchOne('user', (m) => m, dataKey: 'item');
+
+      expect(controller.isSuccess, isTrue);
+      expect(controller.rxState!['id'], equals(1));
+    });
+
+    test('query and headers: forwards both to the request', () async {
+      Http.fake({
+        'user': (request) {
+          expect(request.queryParameters['include'], equals('profile'));
+          expect(request.headers['Authorization'], equals('Bearer token'));
+          return Http.response({
+            'data': {'id': 1},
+          }, 200);
+        },
+      });
+
+      await controller.fetchOne(
+        'user',
+        (m) => m,
+        query: {'include': 'profile'},
+        headers: {'Authorization': 'Bearer token'},
+      );
+    });
+
+    test('loading state: completes with success after loading phase', () async {
+      Http.fake({
+        'user': Http.response({
+          'data': {'id': 1, 'name': 'Alice'},
+        }, 200),
+      });
+
+      await controller.fetchOne('user', (m) => m);
+
+      expect(controller.isSuccess, isTrue);
+      expect(controller.isLoading, isFalse);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Adds `fetchList<E>()` and `fetchOne()` to `MagicStateMixin<T>` for automatic HTTP fetch → state management
- Eliminates ~105 lines of repeated boilerplate per consumer app (7+ state classes × 15 lines each)
- Both methods support custom `dataKey`, `query`, and `headers` parameters

Closes #20

## Test plan

- [x] `flutter test` — 663/663 passing
- [x] `dart analyze` — zero warnings
- [x] fetchList: success, empty, null, error, custom dataKey, query, headers, loading state
- [x] fetchOne: success, null data, error, custom dataKey, query+headers, loading state
- [x] All tests use `Http.fake()` for network stubbing