### PR TITLE
fix(testing): address PR #23 review feedback

### DIFF
--- a/lib/src/facades/log.dart
+++ b/lib/src/facades/log.dart
@@ -1,4 +1,5 @@
 import '../foundation/magic.dart';
+import '../logging/contracts/logger_driver.dart';
 import '../logging/log_manager.dart';
 import '../testing/fake_log_manager.dart';
 
@@ -54,7 +55,7 @@ class Log {
   /// ```dart
   /// Log.channel('slack').error('Server down!');
   /// ```
-  static LogManager channel(String name) => _manager;
+  static LoggerDriver channel(String name) => _manager.driver(name);
 
   /// Replace the bound [LogManager] with a [FakeLogManager] for testing.
   ///

--- a/lib/src/security/magic_vault_service.dart
+++ b/lib/src/security/magic_vault_service.dart
@@ -33,7 +33,6 @@ class MagicVaultService {
   ///
   /// Use this as the `super` constructor in [FakeVaultService] so that the
   /// `late final _storage` field is never assigned and therefore never accessed.
-  // ignore: avoid_unused_constructor_parameters
   MagicVaultService.forTesting();
 
   /// Store a value in the vault.

--- a/skills/magic-framework/references/facades-api.md
+++ b/skills/magic-framework/references/facades-api.md
@@ -382,7 +382,7 @@ Resolves `Magic.make<LogManager>('log')`. Supports all RFC 5424 levels.
 | `Log.info(String message, [dynamic context])` | `void` | Interesting events. |
 | `Log.debug(String message, [dynamic context])` | `void` | Detailed debug information. |
 | `Log.log(String level, String message, [dynamic context])` | `void` | Log at an arbitrary level string. |
-| `Log.channel(String name)` | `LogManager` | Get a named log channel. |
+| `Log.channel(String name)` | `LoggerDriver` | Get a named log channel driver. |
 | `Log.fake()` | `FakeLogManager` | **Testing.** Swap real `LogManager` with `FakeLogManager` that captures entries in memory (no console output). Returns fake for assertions (`assertLogged`, `assertLoggedError`, `assertNothingLogged`, `assertLoggedCount`). |
 | `Log.unfake()` | `void` | **Testing.** Remove fake and restore real `LogManager`. Call in `tearDown`. |
 

--- a/skills/magic-framework/references/secondary-systems.md
+++ b/skills/magic-framework/references/secondary-systems.md
@@ -143,7 +143,7 @@ Multi-channel logging system following RFC 5424 severity levels. Accessed via th
 | `Log.info(message, [context])` | `String message`, `dynamic context` | `void` | Log an informational message. |
 | `Log.debug(message, [context])` | `String message`, `dynamic context` | `void` | Log a detailed debug message. |
 | `Log.log(level, message, [context])` | `String level`, `String message`, `dynamic context` | `void` | Log at an arbitrary level. |
-| `Log.channel(name)` | `String name` | `LogManager` | Get a specific named channel. |
+| `Log.channel(name)` | `String name` | `LoggerDriver` | Get a specific named channel driver. |
 
 ### Usage
 
@@ -790,7 +790,7 @@ await file.storeAs(diskName); // Store with disk selection
 
 - **Cache**: `remember<T>()` returns cached value directly (not awaited) if it exists; only awaits callback on miss.
 - **Events**: Listeners run sequentially. If one throws, others still execute. Errors are logged, not re-thrown.
-- **Logging**: `Log.channel(name)` currently returns the default manager; true multi-channel support per-call is not yet implemented.
+- **Logging**: `Log.channel(name)` returns a `LoggerDriver` resolved via `LogManager.driver(name)`, enabling per-channel logging.
 - **Lang**: `trans()` helper is a shorthand for `Lang.get()`. Translations must be loaded before first use.
 - **Storage**: `put()` returns the path, `get()` returns raw bytes. Use `getFile()` for metadata.
 - **Crypt**: App key must be exactly 32 characters. Device keys are auto-generated on first `encryptWithDeviceKey()` call.

--- a/test/testing/fake_auth_manager_test.dart
+++ b/test/testing/fake_auth_manager_test.dart
@@ -366,7 +366,25 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // 13. guard() always returns same fake guard regardless of name
+  // 13. forgetGuards
+  // ---------------------------------------------------------------------------
+
+  group('forgetGuards', () {
+    test('forgetGuards resets internal guard state', () async {
+      final fake = FakeAuthManager(user: _makeUser());
+
+      await fake.guard().login({'token': 'x'}, _makeUser());
+      expect(fake.guard().check(), isTrue);
+
+      fake.forgetGuards();
+
+      expect(fake.guard().check(), isFalse);
+      expect(await fake.guard().hasToken(), isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 14. guard() always returns same fake guard regardless of name
   // ---------------------------------------------------------------------------
 
   group('guard resolution', () {

--- a/test/testing/fake_cache_manager_test.dart
+++ b/test/testing/fake_cache_manager_test.dart
@@ -244,7 +244,25 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // 7. reset()
+  // 7. driver() and init()
+  // ---------------------------------------------------------------------------
+
+  group('driver and init', () {
+    test('driver returns a CacheStore', () {
+      final fake = FakeCacheManager();
+
+      expect(fake.driver(), isA<CacheStore>());
+    });
+
+    test('init completes without error', () async {
+      final fake = FakeCacheManager();
+
+      await expectLater(fake.init(), completes);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 8. reset()
   // ---------------------------------------------------------------------------
 
   group('reset()', () {

--- a/test/testing/fake_log_manager_test.dart
+++ b/test/testing/fake_log_manager_test.dart
@@ -387,7 +387,29 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // 11. Log.unfake()
+  // 11. Log.channel()
+  // ---------------------------------------------------------------------------
+
+  group('Log.channel()', () {
+    test('returns a LoggerDriver for the named channel', () {
+      Log.fake();
+
+      final driver = Log.channel('console');
+
+      expect(driver, isA<LoggerDriver>());
+    });
+
+    test('channel driver can log messages', () {
+      final fake = Log.fake();
+
+      Log.channel('console').error('channel error');
+
+      fake.assertLoggedError('channel error');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 12. Log.unfake()
   // ---------------------------------------------------------------------------
 
   group('Log.unfake()', () {

--- a/test/testing/fake_vault_service_test.dart
+++ b/test/testing/fake_vault_service_test.dart
@@ -172,7 +172,7 @@ void main() {
   group('Vault.fake() - facade integration', () {
     test('fake() returns FakeVaultService', () {
       final fake = Vault.fake();
-      expect(fake.runtimeType.toString(), equals('FakeVaultService'));
+      expect(fake, isA<FakeVaultService>());
     });
 
     test('fake() registers service in container', () async {
@@ -203,10 +203,7 @@ void main() {
       // After unfake, the container resolves from the singleton binding (not a fake)
       final resolved = Magic.make<MagicVaultService>('vault');
       expect(resolved, isA<MagicVaultService>());
-      expect(
-        resolved.runtimeType.toString(),
-        isNot(equals('FakeVaultService')),
-      );
+      expect(resolved, isNot(isA<FakeVaultService>()));
     });
   });
 }


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #23 (Copilot + Codecov):

**Copilot feedback:**
- **`Log.channel()` return type**: Now returns `LoggerDriver` via `_manager.driver(name)` instead of `LogManager` — enables `Log.channel('slack').error(...)` as documented
- **Unnecessary `// ignore` directive**: Removed from `MagicVaultService.forTesting()` (no unused parameters)
- **Brittle `runtimeType.toString()` assertions**: Replaced with `isA<>()` matchers in vault service tests

**Codecov (8 missing lines):**
- `fake_auth_manager.dart`: Added `forgetGuards()` test
- `fake_cache_manager.dart`: Added `driver()` and `init()` tests
- `fake_log_manager_test.dart`: Added `Log.channel()` tests

Closes review threads on #23.

## Test plan

- [x] `forgetGuards()` resets internal guard state
- [x] `FakeCacheManager.driver()` returns a `CacheStore`
- [x] `FakeCacheManager.init()` completes without error
- [x] `Log.channel()` returns `LoggerDriver` and can log messages
- [x] 668/668 tests passing
- [x] `dart analyze` — zero issues