### PR TITLE
fix(http): address PR #24 review feedback — defensive type guards

### DIFF
--- a/lib/src/http/magic_controller.dart
+++ b/lib/src/http/magic_controller.dart
@@ -220,9 +220,14 @@ mixin MagicStateMixin<T> on MagicController {
       return;
     }
 
-    final items = rawList
-        .map((e) => fromMap(e as Map<String, dynamic>))
-        .toList();
+    final validElements = rawList.whereType<Map<String, dynamic>>();
+
+    if (validElements.isEmpty) {
+      setEmpty();
+      return;
+    }
+
+    final items = validElements.map(fromMap).toList();
 
     setSuccess(items as T);
   }

--- a/skills/magic-framework/references/http-network.md
+++ b/skills/magic-framework/references/http-network.md
@@ -402,9 +402,9 @@ State transition table (both helpers):
 |-----------|-------|
 | Response `failed` (>= 400) | `setError(response.errorMessage ?? 'Failed to load')` |
 | Response body is not a JSON object (`Map`) | `fetchList`: `setEmpty()` / `fetchOne`: `setError('Invalid response format')` |
-| `fetchList`: `dataKey` value is not a `List` or is empty | `setEmpty()` |
+| `fetchList`: `dataKey` value is not a `List`, is empty, or contains no valid `Map` elements | `setEmpty()` |
 | `fetchOne`: `dataKey` value is `null` | `setError('Resource not found')` |
-| `fetchOne`: `dataKey` value is not a `Map<String, dynamic>` | `setError('Invalid response: "dataKey" must contain a JSON object')` |
+| `fetchOne`: `dataKey` value is not a `Map<String, dynamic>` | `setError('Invalid response: "<dataKey>" must contain a JSON object')` (interpolates actual key) |
 | Data present and valid | `setSuccess(parsed)` |
 
 Testing with `Http.fake()`:

--- a/test/http/magic_controller_test.dart
+++ b/test/http/magic_controller_test.dart
@@ -381,5 +381,34 @@ void main() {
 
       expect(controller.isEmpty, isTrue);
     });
+
+    test('list with non-map elements: filters them out gracefully', () async {
+      Http.fake({
+        'items': Http.response({
+          'data': ['string', 42, null],
+        }, 200),
+      });
+
+      await controller.fetchList<Map<String, dynamic>>('items', (m) => m);
+
+      expect(controller.isEmpty, isTrue);
+    });
+
+    test('list with mixed elements: only maps are kept', () async {
+      Http.fake({
+        'items': Http.response({
+          'data': [
+            {'id': 1},
+            'invalid',
+            {'id': 2},
+          ],
+        }, 200),
+      });
+
+      await controller.fetchList<Map<String, dynamic>>('items', (m) => m);
+
+      expect(controller.isSuccess, isTrue);
+      expect(controller.rxState!.length, equals(2));
+    });
   });
 }


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #24 (Copilot). All 4 comments flagged unsafe casts in `fetchList`/`fetchOne`:

- **`response.data[dataKey]` crash on non-Map body**: Now guards with `is Map<String, dynamic>` check — `fetchList` sets empty, `fetchOne` sets error with "Invalid response format"
- **`as List?` cast crash**: Replaced with `is! List` type check — non-list values under `dataKey` gracefully set empty
- **`as Map<String, dynamic>` cast in fetchOne**: Added explicit type check before calling `fromMap` — non-map values under `dataKey` set error with descriptive message
- **`items as T` cast**: Kept as-is (documented risk in plan) — type system can't enforce `T = List<E>` with mixins

Codecov was already clean on #24.

## Test plan

- [x] `fetchList` with non-map response body → `isEmpty`
- [x] `fetchList` with non-list `dataKey` value → `isEmpty`
- [x] `fetchOne` with non-map response body → `isError` "Invalid response format"
- [x] `fetchOne` with non-map `dataKey` value → `isError` "Invalid response"
- [x] 667/667 tests passing
- [x] `dart analyze` — zero issues