### PR TITLE
fix(publish): move flutter_test to dependencies

### DIFF
--- a/lib/src/testing/magic_test.dart
+++ b/lib/src/testing/magic_test.dart
@@ -1,4 +1,3 @@
-// ignore: depend_on_referenced_packages
 import 'package:flutter_test/flutter_test.dart';
 import 'package:magic/magic.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,8 +46,8 @@ dependencies:
   image_picker: ^1.1.2
   faker: ^2.2.0
   magic_cli: ^0.0.1-alpha.3
-
-dev_dependencies:
   flutter_test:
     sdk: flutter
+
+dev_dependencies:
   flutter_lints: ^6.0.0


### PR DESCRIPTION
## Summary
- Move `flutter_test` from `dev_dependencies` to `dependencies` — `MagicTest` in `lib/src/testing/` imports it, which pub.dev validation rejects as a dev-only dependency
- Remove stale `// ignore: depend_on_referenced_packages` comment

## Context
`1.0.0-alpha.6` tag publish failed with:
> `flutter_test is in the dev_dependencies section of pubspec.yaml. Packages used in lib/ must be declared in the dependencies section.`

After merge, re-tag `1.0.0-alpha.6` to trigger publish.

## Verification
- `dart pub publish --dry-run` passes
- All 694 tests pass