### PR TITLE
chore(deps): bump file_picker from 10.3.10 to 11.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### 📦 Dependencies
+- **file_picker**: Upgrade from `^10.3.10` to `^11.0.2` — migrates to static API (`FilePicker.platform` removed). Includes Android path traversal security fix (CWE-22) and WASM web support
+
 ## [1.0.0-alpha.10] - 2026-04-07
 
 ### ✨ New Features

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: file_picker
-      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
+      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.10"
+    version: "11.0.2"
   file_selector_linux:
     dependency: transitive
     description:
@@ -507,7 +507,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-alpha.9"
+    version: "1.0.0-alpha.10"
   magic_cli:
     dependency: transitive
     description:

--- a/lib/src/facades/pick.dart
+++ b/lib/src/facades/pick.dart
@@ -294,7 +294,7 @@ class Pick {
     List<String>? extensions,
     bool withData = true,
   }) async {
-    final result = await FilePicker.platform.pickFiles(
+    final result = await FilePicker.pickFiles(
       type: extensions != null ? FileType.custom : FileType.any,
       allowedExtensions: extensions,
       withData: withData,
@@ -317,7 +317,7 @@ class Pick {
     List<String>? extensions,
     bool withData = true,
   }) async {
-    final result = await FilePicker.platform.pickFiles(
+    final result = await FilePicker.pickFiles(
       allowMultiple: true,
       type: extensions != null ? FileType.custom : FileType.any,
       allowedExtensions: extensions,
@@ -340,7 +340,7 @@ class Pick {
   /// }
   /// ```
   static Future<String?> directory() async {
-    return FilePicker.platform.getDirectoryPath();
+    return FilePicker.getDirectoryPath();
   }
 
   /// Open a save file dialog.
@@ -363,7 +363,7 @@ class Pick {
     String? fileName,
     Uint8List? bytes,
   }) async {
-    return FilePicker.platform.saveFile(
+    return FilePicker.saveFile(
       dialogTitle: dialogTitle,
       fileName: fileName,
       bytes: bytes,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   timezone: ^0.11.0
   url_launcher: ^6.3.0
   logger: ^2.6.2
-  file_picker: ^10.3.10
+  file_picker: ^11.0.2
   image_picker: ^1.1.2
   faker: ^2.2.0
   web_socket_channel: ^3.0.0


### PR DESCRIPTION
## Summary
- Upgrade `file_picker` from `^10.3.10` to `^11.0.2` (major version bump)
- Migrate Pick facade from instance-based API (`FilePicker.platform.method()`) to v11 static API (`FilePicker.method()`)
- Includes Android CWE-22 path traversal security fix and WASM web support

## Breaking Change
`magic.dart` re-exports `package:file_picker/file_picker.dart`. Consumers using `FilePicker.platform` directly (bypassing the `Pick` facade) will get a compile error. The `Pick` facade API is unchanged.

## Changes
- `pubspec.yaml` — `file_picker: ^10.3.10` → `^11.0.2`
- `lib/src/facades/pick.dart` — Remove `.platform` from 4 call sites (lines 297, 320, 343, 366)
- `CHANGELOG.md` — Entry under `[Unreleased]`

## Test plan
- [x] `flutter test` — 914 tests passed
- [x] `dart analyze` — zero warnings
- [x] `dart format . --set-exit-if-changed` — zero changes
- [x] Plan verifier: APPROVE
- [x] Code review: APPROVED

Supersedes #44 (Dependabot PR — only bumped pubspec, did not migrate breaking API).