### PR TITLE
fix(routing): resolve intermittent page title loss on web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+- **Routing**: Fix intermittent page title loss on web — Flutter's `Title` widget was overwriting TitleManager's route-level title on `didChangeDependencies()` rebuilds. Use `onGenerateTitle` to keep both in sync
+
 ### 📦 Dependencies
 - **file_picker**: Upgrade from `^10.3.10` to `^11.0.2` — migrates to static API (`FilePicker.platform` removed). Includes Android path traversal security fix (CWE-22) and WASM web support
 

--- a/lib/src/foundation/magic_app_widget.dart
+++ b/lib/src/foundation/magic_app_widget.dart
@@ -207,7 +207,7 @@ class _MagicApplicationState extends State<MagicApplication> {
         key: MagicAppWidget._appKey,
         themeMode: widget.themeMode,
         builder: (context) => MaterialApp.router(
-          title: widget.title,
+          onGenerateTitle: (_) => TitleManager.instance.effectiveTitle,
           theme: controller.toThemeData(),
           themeMode: widget.themeMode,
           locale: widget.locale ?? _getLocaleFromConfig(),


### PR DESCRIPTION
## Summary
- Fix intermittent page title loss on web — Flutter's internal `Title` widget was overwriting TitleManager's route-level title via `didChangeDependencies()` on InheritedWidget changes (MediaQuery, Locale, Theme)
- Replace `MaterialApp.router(title:)` with `onGenerateTitle` that delegates to `TitleManager.instance.effectiveTitle`
- Also includes `file_picker` upgrade from `^10.3.10` to `^11.0.2` (static API migration, Android CWE-22 security fix)

## Root Cause
`MagicApplication` passed a static `title` to `MaterialApp.router`, which Flutter wraps in a `Title` widget. On web, `Title.didChangeDependencies()` fires on every InheritedWidget change and calls `SystemChrome.setApplicationSwitcherDescription` with the static base title — overwriting TitleManager's route-level title. The race is intermittent because it depends on timing of MediaQuery/Locale/Theme updates during initial page load.

## Changes
- `lib/src/foundation/magic_app_widget.dart:210` — `title: widget.title` → `onGenerateTitle: (_) => TitleManager.instance.effectiveTitle`
- `lib/src/facades/pick.dart` — Migrate `FilePicker.platform.method()` → `FilePicker.method()` (4 call sites)
- `pubspec.yaml` — `file_picker: ^10.3.10` → `^11.0.2`

## Test plan
- [x] `flutter test` — 914 tests passed
- [x] `flutter test test/routing/title_manager_test.dart` — 30 tests passed
- [x] `dart analyze` — zero warnings
- [x] `dart format . --set-exit-if-changed` — zero changes
- [x] Plan verifier: APPROVE (both plans)
- [x] Code review: APPROVED (file_picker plan)

Closes #44 (Dependabot file_picker PR — superseded by this PR which includes both the version bump and breaking API migration).