### PR TITLE
chore(release): 1.0.0-alpha.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.0-alpha.11] - 2026-04-07
+
 ### 🐛 Bug Fixes
 - **Routing**: Fix intermittent page title loss on web — Flutter's `Title` widget was overwriting TitleManager's route-level title on `didChangeDependencies()` rebuilds. Use `onGenerateTitle` to keep both in sync
 
-### 📦 Dependencies
-- **file_picker**: Upgrade from `^10.3.10` to `^11.0.2` — migrates to static API (`FilePicker.platform` removed). Includes Android path traversal security fix (CWE-22) and WASM web support
+### ⚠️ Breaking Changes
+- **file_picker**: Upgrade from `^10.3.10` to `^11.0.2` — migrates to static API (`FilePicker.platform` removed). Consumers using `FilePicker.platform` directly (via `magic.dart` re-export) must switch to `FilePicker.method()`. Includes Android path traversal security fix (CWE-22) and WASM web support
 
 ## [1.0.0-alpha.10] - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - **Routing**: Fix intermittent page title loss on web — Flutter's `Title` widget was overwriting TitleManager's route-level title on `didChangeDependencies()` rebuilds. Use `onGenerateTitle` to keep both in sync
 
 ### ⚠️ Breaking Changes
-- **file_picker**: Upgrade from `^10.3.10` to `^11.0.2` — migrates to static API (`FilePicker.platform` removed). Consumers using `FilePicker.platform` directly (via `magic.dart` re-export) must switch to `FilePicker.method()`. Includes Android path traversal security fix (CWE-22) and WASM web support
+- **file_picker**: Upgrade from `^10.3.10` to `^11.0.2` — migrates to static API (`FilePicker.platform` removed). Consumers using `FilePicker.platform` directly (via `magic.dart` re-export) must switch to static calls (`FilePicker.pickFiles()`, `FilePicker.getDirectoryPath()`, `FilePicker.saveFile()`). Includes Android path traversal security fix (CWE-22) and WASM web support
 
 ## [1.0.0-alpha.10] - 2026-04-07
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic
 description: "A Laravel-inspired Flutter framework with Eloquent ORM, routing, and MVC architecture."
-version: 1.0.0-alpha.10
+version: 1.0.0-alpha.11
 homepage: https://magic.fluttersdk.com
 repository: https://github.com/fluttersdk/magic
 issue_tracker: https://github.com/fluttersdk/magic/issues


### PR DESCRIPTION
## Summary
- Bump version to `1.0.0-alpha.11`
- Move unreleased changelog entries to dated section

## Changelog

### 🐛 Bug Fixes
- **Routing**: Fix intermittent page title loss on web

### ⚠️ Breaking Changes
- **file_picker**: Upgrade to v11 — `FilePicker.platform` removed, migrate to static API

## Verification
- ✅ 914 tests passed
- ✅ `dart analyze` — 0 issues
- ✅ `dart format` — 0 changes
- ✅ `dart pub publish --dry-run` — clean