### PR TITLE
feat(broadcasting): WebSocket reliability — activity monitor, jitter, connection timeout

### DIFF
--- a/.claude/rules/broadcasting.md
+++ b/.claude/rules/broadcasting.md
@@ -95,6 +95,7 @@ final broadcastingConfig = {
         'auth_endpoint': '/broadcasting/auth',
         'reconnect': true,
         'max_reconnect_delay': 30000,
+        'connection_timeout': 15,
         'dedup_buffer_size': 100,
       },
       'null': {'driver': 'null'},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ New Features
+- **Broadcasting**: Client-side activity monitor — detects silent connection loss using Pusher protocol `activity_timeout` and `pusher:ping`/`pusher:pong`. Automatically reconnects when the server stops responding
+
 ## [1.0.0-alpha.11] - 2026-04-07
 
 ### 🐛 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### ✨ New Features
 - **Broadcasting**: Client-side activity monitor — detects silent connection loss using Pusher protocol `activity_timeout` and `pusher:ping`/`pusher:pong`. Automatically reconnects when the server stops responding
 - **Broadcasting**: Random jitter (up to 30%) on reconnection backoff delay — prevents thundering herd when many clients reconnect simultaneously after a server restart
+- **Broadcasting**: Configurable connection establishment timeout (default 15s) — prevents indefinite hang when server doesn't complete the Pusher handshake. Automatically triggers reconnect on timeout
 
 ## [1.0.0-alpha.11] - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ New Features
 - **Broadcasting**: Client-side activity monitor — detects silent connection loss using Pusher protocol `activity_timeout` and `pusher:ping`/`pusher:pong`. Automatically reconnects when the server stops responding
+- **Broadcasting**: Random jitter (up to 30%) on reconnection backoff delay — prevents thundering herd when many clients reconnect simultaneously after a server restart
 
 ## [1.0.0-alpha.11] - 2026-04-07
 

--- a/doc/digging-deeper/broadcasting.md
+++ b/doc/digging-deeper/broadcasting.md
@@ -22,6 +22,7 @@
 - [Connection](#connection)
     - [Connection Lifecycle](#connection-lifecycle)
     - [Reconnection and Heartbeat](#reconnection-and-heartbeat)
+    - [Connection Health Monitoring](#connection-health-monitoring)
     - [Deduplication](#deduplication)
 
 <a name="introduction"></a>
@@ -506,6 +507,17 @@ Pusher protocol error codes determine the reconnect strategy:
 | 4200–4299 | Reconnect with exponential backoff |
 
 The driver handles `pusher:ping` frames automatically, responding with `pusher:pong` to satisfy the server keepalive requirement.
+
+<a name="connection-health-monitoring"></a>
+### Connection Health Monitoring
+
+The `ReverbBroadcastDriver` implements client-side activity monitoring per the Pusher protocol specification. This detects silent connection loss — such as server crashes, network partitions, or deployments that don't send a WebSocket close frame — and automatically triggers reconnection.
+
+- After connecting, the driver starts an inactivity timer using the server-provided `activity_timeout` value (sent in the `pusher:connection_established` handshake)
+- If no message is received within `activity_timeout` seconds, the driver sends a `pusher:ping` to the server
+- If no `pusher:pong` response arrives within 30 seconds, the connection is declared dead and the driver closes the socket, triggering the standard reconnection flow with exponential backoff
+- The inactivity timer resets on **any** inbound message, not just pong responses
+- All timers are cancelled on `disconnect()` and during reconnection cycles to prevent stale timer interference
 
 <a name="deduplication"></a>
 ### Deduplication

--- a/doc/digging-deeper/broadcasting.md
+++ b/doc/digging-deeper/broadcasting.md
@@ -517,7 +517,7 @@ The `ReverbBroadcastDriver` implements client-side activity monitoring per the P
 
 - After connecting, the driver starts an inactivity timer using the server-provided `activity_timeout` value (sent in the `pusher:connection_established` handshake)
 - If no message is received within `activity_timeout` seconds, the driver sends a `pusher:ping` to the server
-- If no `pusher:pong` response arrives within 30 seconds, the connection is declared dead and the driver closes the socket, triggering the standard reconnection flow with exponential backoff
+- If no `pusher:pong` response arrives within the configured `pongTimeout` window (30 seconds by default), the connection is declared dead and the driver closes the socket, triggering the standard reconnection flow with exponential backoff
 - The inactivity timer resets on **any** inbound message, not just pong responses
 - All timers are cancelled on `disconnect()` and during reconnection cycles to prevent stale timer interference
 

--- a/doc/digging-deeper/broadcasting.md
+++ b/doc/digging-deeper/broadcasting.md
@@ -494,7 +494,8 @@ If a private/presence channel auth fails during reconnect, the error is logged v
 
 `ReverbBroadcastDriver` implements automatic reconnection with **exponential backoff**:
 
-- Formula: `min(500ms × 2^attempt, max_reconnect_delay)`
+- Formula: `min(500ms × 2^attempt, max_reconnect_delay) × (1 + jitter)` where jitter is a random value between 0 and 0.3 (30%)
+- The random jitter prevents **thundering herd** — when a server restarts, clients spread their reconnection attempts over time instead of hitting the server at the exact same moment
 - Default `max_reconnect_delay` is 30,000 ms (30 seconds)
 - Set `reconnect: false` in config to disable auto-reconnect
 

--- a/doc/digging-deeper/broadcasting.md
+++ b/doc/digging-deeper/broadcasting.md
@@ -104,6 +104,7 @@ await Magic.init(
 | `reconnect` | `bool` | `true` | Whether to auto-reconnect on unexpected disconnect |
 | `max_reconnect_delay` | `int` | `30000` | Maximum backoff delay in milliseconds |
 | `activity_timeout` | `int` | `120` | Seconds before a heartbeat ping is expected |
+| `connection_timeout` | `int` | `15` | Seconds to wait for `pusher:connection_established` before timing out |
 | `dedup_buffer_size` | `int` | `100` | Number of recent event fingerprints kept for deduplication |
 
 <a name="environment-variables"></a>

--- a/lib/config/broadcasting.dart
+++ b/lib/config/broadcasting.dart
@@ -13,6 +13,7 @@
 /// - `reconnect` — Auto-reconnect on unexpected disconnect
 /// - `max_reconnect_delay` — Maximum back-off delay in milliseconds
 /// - `activity_timeout` — Seconds of inactivity before ping is sent
+/// - `connection_timeout` — Seconds to wait for connection establishment
 /// - `dedup_buffer_size` — Number of recent event IDs kept for deduplication
 final Map<String, dynamic> defaultBroadcastingConfig = {
   'broadcasting': {
@@ -35,6 +36,7 @@ final Map<String, dynamic> defaultBroadcastingConfig = {
         'reconnect': true,
         'max_reconnect_delay': 30000,
         'activity_timeout': 120,
+        'connection_timeout': 15,
         'dedup_buffer_size': 100,
       },
       'null': {'driver': 'null'},

--- a/lib/src/broadcasting/drivers/reverb_broadcast_driver.dart
+++ b/lib/src/broadcasting/drivers/reverb_broadcast_driver.dart
@@ -71,8 +71,15 @@ class ReverbBroadcastDriver implements BroadcastDriver {
       Map<String, dynamic> data,
     )?
     authFactory,
+    this.pongTimeout = _kPongTimeout,
   }) : _channelFactory = channelFactory ?? WebSocketChannel.connect,
        _authFactory = authFactory ?? _defaultAuthFactory;
+
+  // ---------------------------------------------------------------------------
+  // Constants
+  // ---------------------------------------------------------------------------
+
+  static const Duration _kPongTimeout = Duration(seconds: 30);
 
   // ---------------------------------------------------------------------------
   // Dependencies
@@ -85,6 +92,9 @@ class ReverbBroadcastDriver implements BroadcastDriver {
     Map<String, dynamic> data,
   )
   _authFactory;
+
+  /// The duration to wait for a pong response after sending a ping.
+  final Duration pongTimeout;
 
   static Future<Map<String, dynamic>> _defaultAuthFactory(
     String endpoint,
@@ -157,6 +167,13 @@ class ReverbBroadcastDriver implements BroadcastDriver {
 
   Timer? _reconnectTimer;
   int _attempt = 0;
+
+  // ---------------------------------------------------------------------------
+  // Activity monitor
+  // ---------------------------------------------------------------------------
+
+  Timer? _activityTimer;
+  Timer? _pongTimer;
 
   // ---------------------------------------------------------------------------
   // Interceptors
@@ -247,6 +264,7 @@ class ReverbBroadcastDriver implements BroadcastDriver {
   Future<void> disconnect() async {
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
+    _cancelActivityTimers();
     _attempt = 0;
 
     _subscriptionQueue.clear();
@@ -385,6 +403,8 @@ class ReverbBroadcastDriver implements BroadcastDriver {
       );
     }
 
+    _resetActivityTimer();
+
     switch (event) {
       case 'pusher:connection_established':
         _handleConnectionEstablished(json);
@@ -409,6 +429,8 @@ class ReverbBroadcastDriver implements BroadcastDriver {
     activityTimeout = data['activity_timeout'] as int? ?? 30;
     _isConnected = true;
     _attempt = 0;
+
+    _resetActivityTimer();
 
     _connectionStateController.add(BroadcastConnectionState.connected);
 
@@ -634,6 +656,8 @@ class ReverbBroadcastDriver implements BroadcastDriver {
   // ---------------------------------------------------------------------------
 
   void _onDone() {
+    _cancelActivityTimers();
+
     if (_connectionCompleter != null && !_connectionCompleter!.isCompleted) {
       _connectionCompleter!.completeError(
         StateError('WebSocket closed before connection established'),
@@ -722,6 +746,29 @@ class ReverbBroadcastDriver implements BroadcastDriver {
         _scheduleReconnect();
       }
     });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Activity monitor helpers
+  // ---------------------------------------------------------------------------
+
+  void _resetActivityTimer() {
+    _activityTimer?.cancel();
+    _pongTimer?.cancel();
+    _pongTimer = null;
+    _activityTimer = Timer(Duration(seconds: activityTimeout), () {
+      _send({'event': 'pusher:ping', 'data': <String, dynamic>{}});
+      _pongTimer = Timer(pongTimeout, () {
+        _channel?.sink.close();
+      });
+    });
+  }
+
+  void _cancelActivityTimers() {
+    _activityTimer?.cancel();
+    _activityTimer = null;
+    _pongTimer?.cancel();
+    _pongTimer = null;
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/src/broadcasting/drivers/reverb_broadcast_driver.dart
+++ b/lib/src/broadcasting/drivers/reverb_broadcast_driver.dart
@@ -72,8 +72,10 @@ class ReverbBroadcastDriver implements BroadcastDriver {
     )?
     authFactory,
     this.pongTimeout = _kPongTimeout,
+    Random? random,
   }) : _channelFactory = channelFactory ?? WebSocketChannel.connect,
-       _authFactory = authFactory ?? _defaultAuthFactory;
+       _authFactory = authFactory ?? _defaultAuthFactory,
+       _random = random ?? Random();
 
   // ---------------------------------------------------------------------------
   // Constants
@@ -92,6 +94,8 @@ class ReverbBroadcastDriver implements BroadcastDriver {
     Map<String, dynamic> data,
   )
   _authFactory;
+
+  final Random _random;
 
   /// The duration to wait for a pong response after sending a ping.
   final Duration pongTimeout;
@@ -364,13 +368,17 @@ class ReverbBroadcastDriver implements BroadcastDriver {
   // Backoff delay — pure function, exposed for testing
   // ---------------------------------------------------------------------------
 
-  /// Computes the reconnect delay for [attempt] using exponential backoff.
+  /// Computes the reconnect delay for [attempt] using exponential backoff
+  /// with random jitter.
   ///
-  /// Formula: `min(500 * 2^attempt, maxReconnectDelay)` milliseconds.
+  /// Formula: `min(500 * 2^attempt, maxReconnectDelay) * (1 + random(0..0.3))`
+  /// milliseconds. The jitter (up to 30% of base delay) prevents thundering
+  /// herd when many clients reconnect simultaneously after a server restart.
   Duration backoffDelay(int attempt) {
     final maxDelay = _config['max_reconnect_delay'] as int? ?? 30000;
-    final ms = min(500 * pow(2, attempt).toInt(), maxDelay);
-    return Duration(milliseconds: ms);
+    final base = min(500 * pow(2, attempt).toInt(), maxDelay);
+    final jitter = (_random.nextDouble() * base * 0.3).toInt();
+    return Duration(milliseconds: base + jitter);
   }
 
   /// Classifies a Pusher error [code] into a reconnection action.

--- a/lib/src/broadcasting/drivers/reverb_broadcast_driver.dart
+++ b/lib/src/broadcasting/drivers/reverb_broadcast_driver.dart
@@ -261,7 +261,18 @@ class ReverbBroadcastDriver implements BroadcastDriver {
       },
     );
 
-    return _connectionCompleter!.future;
+    final timeout = _config['connection_timeout'] as int? ?? 15;
+    return _connectionCompleter!.future.timeout(
+      Duration(seconds: timeout),
+      onTimeout: () {
+        _channel?.sink.close();
+        _connectionCompleter = null;
+        _scheduleReconnect();
+        throw TimeoutException(
+          'Connection establishment timed out after ${timeout}s',
+        );
+      },
+    );
   }
 
   @override

--- a/lib/src/broadcasting/drivers/reverb_broadcast_driver.dart
+++ b/lib/src/broadcasting/drivers/reverb_broadcast_driver.dart
@@ -387,7 +387,10 @@ class ReverbBroadcastDriver implements BroadcastDriver {
   /// herd when many clients reconnect simultaneously after a server restart.
   Duration backoffDelay(int attempt) {
     final maxDelay = _config['max_reconnect_delay'] as int? ?? 30000;
-    final base = min(500 * pow(2, attempt).toInt(), maxDelay);
+    var base = 500;
+    for (var i = 0; i < attempt && base < maxDelay; i++) {
+      base = min(base * 2, maxDelay);
+    }
     final jitter = (_random.nextDouble() * base * 0.3).toInt();
     return Duration(milliseconds: base + jitter);
   }
@@ -714,6 +717,7 @@ class ReverbBroadcastDriver implements BroadcastDriver {
     final shouldReconnect = _config['reconnect'] as bool? ?? true;
     if (!shouldReconnect) return;
 
+    _cancelActivityTimers();
     _reconnectTimer?.cancel();
 
     final delay = immediate ? Duration.zero : backoffDelay(_attempt);

--- a/test/broadcasting/drivers/reverb_broadcast_driver_test.dart
+++ b/test/broadcasting/drivers/reverb_broadcast_driver_test.dart
@@ -1608,4 +1608,204 @@ void main() {
       await driver.disconnect();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Activity Monitor (client-side ping/pong timeout)
+  // ---------------------------------------------------------------------------
+
+  group('ReverbBroadcastDriver — Activity Monitor', () {
+    test('sends pusher:ping after activity_timeout silence', () async {
+      final mock = _MockWebSocketChannel();
+      final driver = ReverbBroadcastDriver(
+        _defaultConfig(overrides: {'activity_timeout': 1}),
+        channelFactory: (_) => mock,
+        pongTimeout: const Duration(seconds: 1),
+      );
+
+      // Handshake with 1-second activity_timeout.
+      _simulateConnectionEstablished(mock, activityTimeout: 1);
+      await driver.connect();
+
+      // Clear handshake frames.
+      mock._sink.messages.clear();
+
+      // Wait longer than activity_timeout (1s) for ping to be sent.
+      await Future<void>.delayed(const Duration(milliseconds: 1200));
+
+      final frames = mock.sentFrames;
+      expect(
+        frames,
+        contains(
+          predicate<Map<String, dynamic>>((f) => f['event'] == 'pusher:ping'),
+        ),
+        reason: 'Driver should send pusher:ping after activity_timeout silence',
+      );
+
+      await driver.disconnect();
+    });
+
+    test('reconnects when pong not received within timeout', () async {
+      final mock = _MockWebSocketChannel();
+      final driver = ReverbBroadcastDriver(
+        _defaultConfig(overrides: {'activity_timeout': 1, 'reconnect': false}),
+        channelFactory: (_) => mock,
+        pongTimeout: const Duration(seconds: 1),
+      );
+
+      _simulateConnectionEstablished(mock, activityTimeout: 1);
+      await driver.connect();
+
+      // Wait for activity_timeout (1s) + pong timeout (1s) + buffer.
+      await Future<void>.delayed(const Duration(milliseconds: 2500));
+
+      // Socket should have been closed (triggering reconnect via _onDone).
+      expect(
+        mock._sink.isClosed,
+        isTrue,
+        reason:
+            'Socket should be closed when pong is not received within timeout',
+      );
+
+      await driver.disconnect();
+    });
+
+    test('resets activity timer on any inbound message', () async {
+      final mock = _MockWebSocketChannel();
+      final driver = ReverbBroadcastDriver(
+        _defaultConfig(overrides: {'activity_timeout': 1}),
+        channelFactory: (_) => mock,
+        pongTimeout: const Duration(seconds: 1),
+      );
+
+      _simulateConnectionEstablished(mock, activityTimeout: 1);
+      await driver.connect();
+
+      // Clear handshake frames.
+      mock._sink.messages.clear();
+
+      // Wait 700ms (partial timeout — less than 1s activity_timeout).
+      await Future<void>.delayed(const Duration(milliseconds: 700));
+
+      // Send a data message — should reset the activity timer.
+      mock.simulateMessage({
+        'event': 'SomeEvent',
+        'channel': 'orders',
+        'data': jsonEncode({'id': 1}),
+      });
+
+      // Wait another 700ms — total 1400ms since connect, but only 700ms since
+      // last inbound message, so ping should NOT have been sent.
+      await Future<void>.delayed(const Duration(milliseconds: 700));
+
+      final frames = mock.sentFrames;
+      final pings = frames.where((f) => f['event'] == 'pusher:ping');
+      expect(
+        pings,
+        isEmpty,
+        reason:
+            'No ping should be sent because activity timer was reset by '
+            'inbound message',
+      );
+
+      await driver.disconnect();
+    });
+
+    test('cancels activity timers on disconnect', () async {
+      final mock = _MockWebSocketChannel();
+      final driver = ReverbBroadcastDriver(
+        _defaultConfig(overrides: {'activity_timeout': 1}),
+        channelFactory: (_) => mock,
+        pongTimeout: const Duration(seconds: 1),
+      );
+
+      _simulateConnectionEstablished(mock, activityTimeout: 1);
+      await driver.connect();
+
+      // Clear handshake frames.
+      mock._sink.messages.clear();
+
+      // Disconnect immediately.
+      await driver.disconnect();
+
+      // Wait longer than activity_timeout.
+      await Future<void>.delayed(const Duration(milliseconds: 1500));
+
+      // No ping should have been sent after disconnect.
+      final frames = mock._sink.sentFrames;
+      final pings = frames.where((f) {
+        final decoded = jsonDecode(f as String) as Map<String, dynamic>;
+        return decoded['event'] == 'pusher:ping';
+      });
+      expect(pings, isEmpty, reason: 'No ping should be sent after disconnect');
+    });
+
+    test('restarts activity monitor after reconnect', () async {
+      _MockWebSocketChannel? firstConnection;
+      _MockWebSocketChannel? secondConnection;
+      var connectionCount = 0;
+
+      final driver = ReverbBroadcastDriver(
+        _defaultConfig(overrides: {'activity_timeout': 1, 'reconnect': true}),
+        channelFactory: (_) {
+          connectionCount++;
+          if (connectionCount == 1) {
+            firstConnection = _MockWebSocketChannel();
+            // Schedule handshake for first connection.
+            Future<void>.delayed(Duration.zero, () {
+              firstConnection!.simulateMessage({
+                'event': 'pusher:connection_established',
+                'data': jsonEncode({
+                  'socket_id': 'first-socket-id',
+                  'activity_timeout': 1,
+                }),
+              });
+            });
+            return firstConnection!;
+          }
+          secondConnection = _MockWebSocketChannel();
+          // Schedule handshake for reconnected connection.
+          Future<void>.delayed(Duration.zero, () {
+            secondConnection!.simulateMessage({
+              'event': 'pusher:connection_established',
+              'data': jsonEncode({
+                'socket_id': 'reconnected-socket-id',
+                'activity_timeout': 1,
+              }),
+            });
+          });
+          return secondConnection!;
+        },
+        pongTimeout: const Duration(seconds: 1),
+      );
+
+      await driver.connect();
+
+      // Simulate server closing the connection — triggers reconnect.
+      firstConnection!.simulateClose();
+
+      // Wait for reconnect (500ms backoff) + handshake.
+      await Future<void>.delayed(const Duration(milliseconds: 700));
+
+      // Clear frames on new connection.
+      secondConnection!._sink.messages.clear();
+
+      // Wait for activity_timeout (1s) on the new connection.
+      await Future<void>.delayed(const Duration(milliseconds: 1200));
+
+      // Activity monitor should have restarted — ping should be sent on new
+      // connection.
+      final frames = secondConnection!.sentFrames;
+      expect(
+        frames,
+        contains(
+          predicate<Map<String, dynamic>>((f) => f['event'] == 'pusher:ping'),
+        ),
+        reason:
+            'Activity monitor should restart after reconnect and send ping '
+            'on new connection',
+      );
+
+      await driver.disconnect();
+    });
+  });
 }

--- a/test/broadcasting/drivers/reverb_broadcast_driver_test.dart
+++ b/test/broadcasting/drivers/reverb_broadcast_driver_test.dart
@@ -237,6 +237,66 @@ void main() {
       expect(driver.socketId, isNull);
       expect(states, contains(BroadcastConnectionState.disconnected));
     });
+
+    test('throws TimeoutException when server does not send '
+        'connection_established within timeout', () async {
+      final mock = _MockWebSocketChannel();
+      final driver = ReverbBroadcastDriver(
+        _defaultConfig(
+          overrides: {'connection_timeout': 1, 'reconnect': false},
+        ),
+        channelFactory: (_) => mock,
+      );
+
+      // Do NOT simulate connection_established — server is unresponsive.
+      expect(driver.connect(), throwsA(isA<TimeoutException>()));
+
+      await Future<void>.delayed(const Duration(milliseconds: 1200));
+
+      // Socket should have been closed.
+      expect(mock._sink.isClosed, isTrue);
+    });
+
+    test('schedules reconnect after connection timeout', () async {
+      final mock1 = _MockWebSocketChannel();
+      _MockWebSocketChannel? mock2;
+      var connectionCount = 0;
+
+      final driver = ReverbBroadcastDriver(
+        _defaultConfig(overrides: {'connection_timeout': 1, 'reconnect': true}),
+        channelFactory: (_) {
+          connectionCount++;
+          if (connectionCount == 1) return mock1;
+          mock2 = _MockWebSocketChannel();
+          Future<void>.delayed(Duration.zero, () {
+            mock2!.simulateMessage({
+              'event': 'pusher:connection_established',
+              'data': jsonEncode({
+                'socket_id': 'retry-socket-id',
+                'activity_timeout': 30,
+              }),
+            });
+          });
+          return mock2!;
+        },
+        random: Random(42),
+      );
+
+      // connect() will timeout, but reconnect should be scheduled.
+      try {
+        await driver.connect();
+      } on TimeoutException catch (_) {
+        // Expected.
+      }
+
+      // Wait for reconnect timer (attempt 0 backoff ~500ms + jitter + connect).
+      await Future<void>.delayed(const Duration(milliseconds: 900));
+
+      // Driver should have reconnected successfully.
+      expect(connectionCount, greaterThanOrEqualTo(2));
+
+      await driver.disconnect();
+    });
   });
 
   group('ReverbBroadcastDriver — ping/pong', () {

--- a/test/broadcasting/drivers/reverb_broadcast_driver_test.dart
+++ b/test/broadcasting/drivers/reverb_broadcast_driver_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:magic/magic.dart';
@@ -523,42 +524,50 @@ void main() {
   });
 
   group('ReverbBroadcastDriver — exponential backoff', () {
-    test('computes correct backoff delays capped at max', () {
+    test('computes backoff delays within expected range with jitter', () {
       final driver = ReverbBroadcastDriver(
         _defaultConfig(overrides: {'max_reconnect_delay': 16000}),
       );
 
-      // Formula: min(500 * 2^attempt, maxDelay)
-      expect(driver.backoffDelay(0), equals(const Duration(milliseconds: 500)));
-      expect(
-        driver.backoffDelay(1),
-        equals(const Duration(milliseconds: 1000)),
-      );
-      expect(
-        driver.backoffDelay(2),
-        equals(const Duration(milliseconds: 2000)),
-      );
-      expect(
-        driver.backoffDelay(3),
-        equals(const Duration(milliseconds: 4000)),
-      );
-      expect(
-        driver.backoffDelay(4),
-        equals(const Duration(milliseconds: 8000)),
-      );
-      expect(
-        driver.backoffDelay(5),
-        equals(const Duration(milliseconds: 16000)),
-      );
+      // Formula: base = min(500 * 2^attempt, maxDelay), jitter = 0..30%
+      // Result is in [base, base * 1.3]
+      void expectRange(int attempt, int base) {
+        final delay = driver.backoffDelay(attempt);
+        final ms = delay.inMilliseconds;
+        final maxWithJitter = (base * 1.3).ceil();
+        expect(
+          ms,
+          greaterThanOrEqualTo(base),
+          reason: 'attempt $attempt: $ms should be >= $base',
+        );
+        expect(
+          ms,
+          lessThanOrEqualTo(maxWithJitter),
+          reason: 'attempt $attempt: $ms should be <= $maxWithJitter',
+        );
+      }
+
+      expectRange(0, 500);
+      expectRange(1, 1000);
+      expectRange(2, 2000);
+      expectRange(3, 4000);
+      expectRange(4, 8000);
+      expectRange(5, 16000);
       // Capped at max.
-      expect(
-        driver.backoffDelay(6),
-        equals(const Duration(milliseconds: 16000)),
+      expectRange(6, 16000);
+      expectRange(10, 16000);
+    });
+
+    test('produces deterministic delays with seeded Random', () {
+      final driver = ReverbBroadcastDriver(
+        _defaultConfig(overrides: {'max_reconnect_delay': 16000}),
+        random: Random(42),
       );
-      expect(
-        driver.backoffDelay(10),
-        equals(const Duration(milliseconds: 16000)),
-      );
+
+      // With a seeded Random, delays are deterministic but include jitter.
+      final delay0 = driver.backoffDelay(0);
+      expect(delay0.inMilliseconds, greaterThan(500));
+      expect(delay0.inMilliseconds, lessThanOrEqualTo(650));
     });
   });
 
@@ -665,6 +674,7 @@ void main() {
           });
           return mock2;
         },
+        random: Random(42),
       );
 
       // Connect and subscribe to two channels.
@@ -1353,6 +1363,7 @@ void main() {
           return reconnectMock!;
         },
         authFactory: authFactory,
+        random: Random(42),
       );
 
       _simulateConnectionEstablished(mock1);

--- a/test/broadcasting/drivers/reverb_broadcast_driver_test.dart
+++ b/test/broadcasting/drivers/reverb_broadcast_driver_test.dart
@@ -249,9 +249,7 @@ void main() {
       );
 
       // Do NOT simulate connection_established — server is unresponsive.
-      expect(driver.connect(), throwsA(isA<TimeoutException>()));
-
-      await Future<void>.delayed(const Duration(milliseconds: 1200));
+      await expectLater(driver.connect(), throwsA(isA<TimeoutException>()));
 
       // Socket should have been closed.
       expect(mock._sink.isClosed, isTrue);
@@ -1715,7 +1713,7 @@ void main() {
       await driver.disconnect();
     });
 
-    test('reconnects when pong not received within timeout', () async {
+    test('closes socket when pong not received within timeout', () async {
       final mock = _MockWebSocketChannel();
       final driver = ReverbBroadcastDriver(
         _defaultConfig(overrides: {'activity_timeout': 1, 'reconnect': false}),


### PR DESCRIPTION
## Summary

Three broadcasting reliability improvements for `ReverbBroadcastDriver`:

- **Client-side activity monitor** (#55) — Implements Pusher protocol `activity_timeout` + `pusher:ping`/`pusher:pong`. Detects silent connection loss and triggers automatic reconnection
- **Reconnection jitter** (#56) — Adds random jitter (up to 30%) to exponential backoff, preventing thundering herd when server restarts
- **Connection establishment timeout** (#57) — Configurable timeout (default 15s) on `connect()` prevents indefinite hang when server doesn't complete handshake

Closes #55, closes #56, closes #57

## Changes

### Activity Monitor (#55)
- `reverb_broadcast_driver.dart` — `_activityTimer`, `_pongTimer` fields, `_resetActivityTimer()` / `_cancelActivityTimers()` methods, wired into `_onMessage()`, `_handleConnectionEstablished()`, `disconnect()`, `_onDone()`
- 5 new test cases (ping after silence, pong timeout reconnect, timer reset on message, cancel on disconnect, restart after reconnect)

### Reconnection Jitter (#56)
- `reverb_broadcast_driver.dart` — `backoffDelay()` formula updated to `base * (1 + random(0..0.3))`, `Random` DI via constructor
- Tests updated from exact equality to range matchers + seeded Random for determinism

### Connection Timeout (#57)
- `reverb_broadcast_driver.dart` — `connect()` uses `.timeout()` with configurable `connection_timeout` (default 15s), schedules reconnect on timeout
- `config/broadcasting.dart` — Added `connection_timeout: 15` default
- 2 new test cases (throws TimeoutException, schedules reconnect after timeout)

### Docs & Config
- `doc/digging-deeper/broadcasting.md` — Connection Health Monitoring section, jitter formula, `connection_timeout` config
- `CHANGELOG.md` — 3 feature entries under [Unreleased]
- `.claude/rules/broadcasting.md` — Updated config example

## Test plan
- [x] `flutter test` — 922 tests pass (914 existing + 8 new)
- [x] `dart analyze` — zero issues
- [x] `dart format --set-exit-if-changed .` — zero changes