### PR TITLE
feat: add currentPath property to MagicRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ New Features
+- **Routing**: Add `currentPath` getter to `MagicRouter` — returns the current route path without query string, complementing the existing `currentLocation` property
+
 ## [1.0.0-alpha.12] - 2026-04-09
 
 ### ✨ New Features

--- a/lib/src/routing/magic_router.dart
+++ b/lib/src/routing/magic_router.dart
@@ -558,6 +558,16 @@ class MagicRouter {
   /// ```
   String? get currentLocation => _currentState?.uri.toString();
 
+  /// Get the current route path (without query string).
+  ///
+  /// Returns `null` if no route state is available yet.
+  ///
+  /// ```dart
+  /// final path = MagicRouter.instance.currentPath;
+  /// // e.g. '/profile'
+  /// ```
+  String? get currentPath => _currentState?.uri.path;
+
   // ---------------------------------------------------------------------------
   // Intended URL (Redirect-After-Login)
   // ---------------------------------------------------------------------------

--- a/skills/magic-framework/references/routing-navigation.md
+++ b/skills/magic-framework/references/routing-navigation.md
@@ -196,6 +196,9 @@ final allQueryParams = MagicRouter.instance.queryParameters;
 
 // Current location (path + query)
 final location = MagicRouter.instance.currentLocation;
+
+// Current path only (without query string)
+final path = MagicRouter.instance.currentPath;
 ```
 
 ## Named Routes

--- a/test/routing/router_test.dart
+++ b/test/routing/router_test.dart
@@ -243,6 +243,43 @@ void main() {
     test('currentLocation returns null when no state is set', () {
       expect(MagicRouter.instance.currentLocation, isNull);
     });
+
+    test('currentPath returns null when no state is set', () {
+      expect(MagicRouter.instance.currentPath, isNull);
+    });
+  });
+
+  group('currentPath', () {
+    testWidgets('returns path without query string', (tester) async {
+      MagicRoute.page('/', () => const SizedBox());
+      MagicRoute.page('/profile', () => const SizedBox());
+
+      await tester.pumpWidget(
+        MaterialApp.router(routerConfig: MagicRouter.instance.routerConfig),
+      );
+      await tester.pumpAndSettle();
+
+      MagicRouter.instance.to('/profile', queryParameters: {'tab': 'security'});
+      await tester.pumpAndSettle();
+
+      expect(MagicRouter.instance.currentPath, '/profile');
+      expect(MagicRouter.instance.currentLocation, contains('tab=security'));
+    });
+
+    testWidgets('returns path for simple routes', (tester) async {
+      MagicRoute.page('/', () => const SizedBox());
+      MagicRoute.page('/home', () => const SizedBox());
+
+      await tester.pumpWidget(
+        MaterialApp.router(routerConfig: MagicRouter.instance.routerConfig),
+      );
+      await tester.pumpAndSettle();
+
+      MagicRouter.instance.to('/home');
+      await tester.pumpAndSettle();
+
+      expect(MagicRouter.instance.currentPath, '/home');
+    });
   });
 
   group('Layout Merging', () {


### PR DESCRIPTION
## Summary

Added `currentPath` getter to `MagicRouter` that returns the current route path without query string, complementing the existing `currentLocation` property.

## Changes Made

- `lib/src/routing/magic_router.dart:562-571` — Added `currentPath` getter with dartdoc and example, following `currentLocation` pattern
- `test/routing/router_test.dart:244-246` — Unit test: `currentPath` returns `null` when no state is set
- `test/routing/router_test.dart:249-280` — Widget tests: `currentPath` returns path without query string, returns path for simple routes
- `CHANGELOG.md:5-7` — Added entry under `[Unreleased]`
- `skills/magic-framework/references/routing-navigation.md:201-202` — Added `currentPath` example alongside `currentLocation`

## Tests

- `test/routing/router_test.dart` — 3 new tests (48 total, all passing)
- Test command: `flutter test test/routing/router_test.dart` — 48 passed, 0 failed

## Execution Stats

- Complexity: simple
- Waves: 2/2
- Steps: 2/2 (0 failed)
- Tier distribution: 2 mid, 0 quick, 0 senior
- Escalations: 0
- Verification: build + test + lint — all green

## Decisions

- Excluded `example/pubspec.lock` from commits — auto-generated lockfile change from `flutter pub get` during analysis, not a deliberate modification

## Open Questions

- The `skills/magic-framework/` directory note in CLAUDE.md mentions syncing changes to `fluttersdk/ai` repo — user should be reminded to sync


---

Closes #61

*Generated by [Kodizm AI](https://ai.kodizm.com/projects/019d8d87-e969-706d-be7a-c4eae85f72d6/tasks/019d8d8e-d782-71b7-86c0-f98a6bb0b854)*
