### PR TITLE
chore(release): 1.0.0-alpha.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.0-alpha.13] - 2026-04-16
+
 ### ✨ New Features
 - **Routing**: Add `currentPath` getter to `MagicRouter` — returns the current route path without query string, complementing the existing `currentLocation` property
+
+### 🐛 Bug Fixes
+- **Routing**: Use `GoRouter.pop()` instead of `Navigator.pop()` in `back()` — syncs router state and preserves custom page transitions on reverse animation. Add `StateError` guard when router is not initialized, consistent with `to()` and `replace()`
+
+### 🔧 Improvements
+- **Skill**: Optimize `magic-framework` skill for Claude Code progressive disclosure — split frontmatter, extract templates to references, compress sections (669 → 416 lines). Add version frontmatter and source-to-skill mapping in release command
+- **Deps**: Bump magic version constraint in example app
 
 ## [1.0.0-alpha.12] - 2026-04-09
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -507,7 +507,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-alpha.12"
+    version: "1.0.0-alpha.13"
   magic_cli:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.9
   magic:
     path: ..
-    version: 1.0.0-alpha.12
+    version: 1.0.0-alpha.13
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic
 description: "A Laravel-inspired Flutter framework with Eloquent ORM, routing, and MVC architecture."
-version: 1.0.0-alpha.12
+version: 1.0.0-alpha.13
 homepage: https://magic.fluttersdk.com
 repository: https://github.com/fluttersdk/magic
 issue_tracker: https://github.com/fluttersdk/magic/issues

--- a/skills/magic-framework/SKILL.md
+++ b/skills/magic-framework/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: magic-framework
 description: "Magic Framework: Flutter IoC + 17 Facades (Auth, Http, Cache, DB, Echo, Log, Event, Gate, MagicRoute...), Eloquent ORM, Service Providers, GoRouter, MagicController/View, forms, testing, 4 plugins."
-version: 1.0.0-alpha.12
+version: 1.0.0-alpha.13
 when_to_use: "TRIGGER when: code imports `package:magic/magic.dart` or `package:magic/testing.dart`, or user mentions Magic.init, MagicApp, MagicController, MagicView, MagicStatefulView, MagicStatefulViewState, MagicResponsiveView, MagicFormData, MagicForm, MagicBuilder, MagicRoute, MagicResponse, Model with HasTimestamps, InteractsWithPersistence, ServiceProvider, MagicMiddleware, MagicStateMixin, ValidatesRequests, RxStatus, Auth/Http/Config/Cache/DB/Gate/Log/Event/Lang/Schema/Vault/Storage/Pick/Crypt/Launch/Echo facade, MagicApplication, MagicTitle, TitleManager, MagicTest, fetchList, fetchOne, Http.fake, Auth.fake, Echo.fake, Magic.findOrPut, Magic.make, Magic.put, Magic.find, Magic.singleton, Magic.snackbar, Magic.toast, Magic.dialog, Magic.confirm, Carbon, trans(), env(), rules(), handleApiError, MagicStarter, magic_deeplink, magic_notifications, magic_social_auth, dart run magic:magic, make:model, make:controller, make:view. DO NOT TRIGGER when: code only uses Wind UI without Magic framework, or plain Flutter without package:magic import."
 ---
 
-<!-- Magic v1.0.0-alpha.12 | magic_starter v0.0.1-alpha.14 | Skill updated: 2026-04-16 -->
+<!-- Magic v1.0.0-alpha.13 | magic_starter v0.0.1-alpha.14 | Skill updated: 2026-04-16 -->
 
 # Magic Framework
 


### PR DESCRIPTION
## Summary

- Bump version to `1.0.0-alpha.13`
- Update CHANGELOG with entries from alpha.12

### Changelog

**New Features**
- `currentPath` getter on MagicRouter

**Bug Fixes**
- Use GoRouter.pop() in back() for proper state sync + StateError guard

**Improvements**
- Optimize magic-framework skill for CC progressive disclosure (669 -> 416 lines)
- Bump example dep constraint

## Test plan

- [x] `flutter test` (926 passed)
- [x] `dart analyze` (zero issues)
- [x] `dart format` (zero changes)
- [x] `dart pub publish --dry-run` (zero real warnings)