### PR TITLE
feat(eloquent): CastsAttributes interface for class-based custom casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to this project will be documented in this file.
 - **Eloquent**: `CastsAttributes<T>` interface for class-based custom casts. `Model.casts` now accepts either the legacy string types (`datetime`, `json`, `bool`, `int`, `double`) or a `CastsAttributes` instance. Ships with two built-ins: `EnumCast<T extends Enum>` (with optional `strict` mode) and `ListCast<T>` (element-wise JSON round-trip). (#71)
 
 ### 🔧 Improvements
-- **Eloquent**: `Model.casts` return type widened from `Map<String, String>` to `Map<String, dynamic>`. Existing subclasses returning `Map<String, String>` remain valid via covariant override.
+- **Eloquent**: `Model.casts` return type widened from `Map<String, String>` to `Map<String, dynamic>`. Existing subclasses returning `Map<String, String>` remain valid because `Map<String, String>` is a subtype of `Map<String, dynamic>` under Dart's generic covariance.
+- **Eloquent**: Built-in `json` cast now handles both `Map` and `List` JSON values. Reads decode to whichever type the stored JSON represents; writes encode either shape to a JSON string for storage.
 
 ## [1.0.0-alpha.13] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ New Features
+- **Eloquent**: `CastsAttributes<T>` interface for class-based custom casts. `Model.casts` now accepts either the legacy string types (`datetime`, `json`, `bool`, `int`, `double`) or a `CastsAttributes` instance. Ships with two built-ins: `EnumCast<T extends Enum>` (with optional `strict` mode) and `ListCast<T>` (element-wise JSON round-trip). (#71)
+
+### 🔧 Improvements
+- **Eloquent**: `Model.casts` return type widened from `Map<String, String>` to `Map<String, dynamic>`. Existing subclasses returning `Map<String, String>` remain valid via covariant override.
+
 ## [1.0.0-alpha.13] - 2026-04-16
 
 ### ✨ New Features

--- a/doc/eloquent/mutators.md
+++ b/doc/eloquent/mutators.md
@@ -115,6 +115,47 @@ class Task extends Model {
 | `datetime` | `Carbon` | TEXT (ISO 8601) |
 | `json` | `Map` or `List` | TEXT (JSON) |
 
+### Custom Casts (`CastsAttributes`)
+
+For domain types like enums or value objects, implement `CastsAttributes<T>` and register the instance in `casts`:
+
+```dart
+enum MonitorStatus { active, paused, failed }
+
+class Monitor extends Model {
+  @override
+  Map<String, dynamic> get casts => {
+    'status': EnumCast(MonitorStatus.values),      // enum round-trip
+    'tags': ListCast(EnumCast(MonitorTag.values)), // list of enums
+    'created_at': 'datetime',                       // built-ins still work
+  };
+
+  MonitorStatus? get status => getAttribute('status') as MonitorStatus?;
+  set status(MonitorStatus? value) => setAttribute('status', value);
+}
+```
+
+Two casts ship with Magic:
+
+- **`EnumCast<T extends Enum>(values, {strict = false})`** — resolves a raw name to its enum value. Set `strict: true` to throw `ArgumentError` on unknown names instead of returning `null`.
+- **`ListCast<T>(inner)`** — applies `inner` to every list element. Stored as a JSON-encoded string.
+
+Roll your own by implementing `CastsAttributes<T>`:
+
+```dart
+class MoneyCast implements CastsAttributes<Money> {
+  const MoneyCast();
+
+  @override
+  Money? get(Model model, String key, Object? raw) =>
+      raw == null ? null : Money.fromCents(raw as int);
+
+  @override
+  Object? set(Model model, String key, Object? value) =>
+      value is Money ? value.cents : value;
+}
+```
+
 <a name="date-casting"></a>
 ## Date Casting
 

--- a/doc/eloquent/mutators.md
+++ b/doc/eloquent/mutators.md
@@ -125,9 +125,9 @@ enum MonitorStatus { active, paused, failed }
 class Monitor extends Model {
   @override
   Map<String, dynamic> get casts => {
-    'status': EnumCast(MonitorStatus.values),      // enum round-trip
-    'tags': ListCast(EnumCast(MonitorTag.values)), // list of enums
-    'created_at': 'datetime',                       // built-ins still work
+    'status': EnumCast(MonitorStatus.values),         // enum round-trip
+    'statuses': ListCast(EnumCast(MonitorStatus.values)), // list of enums
+    'created_at': 'datetime',                         // built-ins still work
   };
 
   MonitorStatus? get status => getAttribute('status') as MonitorStatus?;

--- a/lib/magic.dart
+++ b/lib/magic.dart
@@ -123,6 +123,9 @@ export 'src/database/seeding/seeder.dart';
 export 'src/database/eloquent/model.dart';
 export 'src/database/eloquent/concerns/has_timestamps.dart';
 export 'src/database/eloquent/concerns/interacts_with_persistence.dart';
+export 'src/database/eloquent/casts/casts_attributes.dart';
+export 'src/database/eloquent/casts/enum_cast.dart';
+export 'src/database/eloquent/casts/list_cast.dart';
 
 // Authentication
 export 'src/auth/authenticatable.dart';

--- a/lib/src/database/eloquent/casts/casts_attributes.dart
+++ b/lib/src/database/eloquent/casts/casts_attributes.dart
@@ -1,0 +1,40 @@
+import '../model.dart';
+
+/// Contract for class-based custom attribute casts.
+///
+/// Implement this interface to define a reusable cast that transforms a raw
+/// storage value into a domain type on read, and back into a storage value on
+/// write. Register the instance under the attribute name in [Model.casts]:
+///
+/// ```dart
+/// class EnumCast<T extends Enum> implements CastsAttributes<T> { ... }
+///
+/// class Monitor extends Model {
+///   @override
+///   Map<String, dynamic> get casts => {
+///     'status': EnumCast(MonitorStatus.values),
+///     'created_at': 'datetime',
+///   };
+/// }
+/// ```
+///
+/// The string-based built-ins (`datetime`, `json`, `bool`, `int`, `double`)
+/// continue to work side by side.
+abstract class CastsAttributes<T> {
+  const CastsAttributes();
+
+  /// Transform the raw storage value into the domain type.
+  ///
+  /// Called from [Model.getAttribute] when reading the attribute. Receives
+  /// the value exactly as it sits in storage (API response, database row, or
+  /// a previously-set domain value).
+  T? get(Model model, String key, Object? raw);
+
+  /// Transform the domain value back into a storage representation.
+  ///
+  /// Called from [Model.setAttribute] when writing the attribute. If the
+  /// incoming value is not of type [T] (e.g. raw string from a fill), the
+  /// implementation should return it unchanged so hydration flows keep
+  /// working.
+  Object? set(Model model, String key, Object? value);
+}

--- a/lib/src/database/eloquent/casts/enum_cast.dart
+++ b/lib/src/database/eloquent/casts/enum_cast.dart
@@ -1,0 +1,65 @@
+import '../model.dart';
+import 'casts_attributes.dart';
+
+/// Cast a string-backed enum attribute to/from its Dart [Enum] value.
+///
+/// Pass the enum's `.values` list so the cast can resolve names back to
+/// instances:
+///
+/// ```dart
+/// enum MonitorStatus { active, paused, failed }
+///
+/// class Monitor extends Model {
+///   @override
+///   Map<String, dynamic> get casts => {
+///     'status': EnumCast(MonitorStatus.values),
+///   };
+///
+///   MonitorStatus? get status => getAttribute('status') as MonitorStatus?;
+///   set status(MonitorStatus? value) => setAttribute('status', value);
+/// }
+/// ```
+///
+/// Unknown names return `null` by default. Pass `strict: true` to throw an
+/// [ArgumentError] instead, useful when the backend should never ship an
+/// unexpected value.
+class EnumCast<T extends Enum> implements CastsAttributes<T> {
+  const EnumCast(this.values, {this.strict = false});
+
+  /// The enum's `.values` list used to resolve names.
+  final List<T> values;
+
+  /// When `true`, an unknown name throws [ArgumentError] instead of returning
+  /// `null`.
+  final bool strict;
+
+  @override
+  T? get(Model model, String key, Object? raw) {
+    if (raw == null) return null;
+    if (raw is T) return raw;
+
+    final name = raw.toString();
+    for (final value in values) {
+      if (value.name == name) return value;
+    }
+
+    if (strict) {
+      throw ArgumentError.value(
+        raw,
+        key,
+        'Unknown $T value. Expected one of: '
+        '${values.map((v) => v.name).join(', ')}',
+      );
+    }
+
+    return null;
+  }
+
+  @override
+  Object? set(Model model, String key, Object? value) {
+    if (value == null) return null;
+    if (value is T) return value.name;
+    // Allow raw strings to pass through for hydration flows.
+    return value;
+  }
+}

--- a/lib/src/database/eloquent/casts/list_cast.dart
+++ b/lib/src/database/eloquent/casts/list_cast.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+
+import '../model.dart';
+import 'casts_attributes.dart';
+
+/// Cast a list attribute element-by-element through an inner cast.
+///
+/// Storage form is a JSON-encoded string (so it survives SQLite TEXT columns
+/// and API round-trips). Reads accept either a `List` or a JSON string; writes
+/// always emit JSON.
+///
+/// ```dart
+/// class Monitor extends Model {
+///   @override
+///   Map<String, dynamic> get casts => {
+///     'tags': ListCast(EnumCast(MonitorTag.values)),
+///   };
+/// }
+/// ```
+class ListCast<T> implements CastsAttributes<List<T>> {
+  const ListCast(this.inner);
+
+  /// The per-element cast applied to every item in the list.
+  final CastsAttributes<T> inner;
+
+  @override
+  List<T>? get(Model model, String key, Object? raw) {
+    if (raw == null) return null;
+
+    final List<dynamic> items = switch (raw) {
+      final List<dynamic> list => list,
+      final String s => jsonDecode(s) as List<dynamic>,
+      _ => <dynamic>[raw],
+    };
+
+    final result = <T>[];
+    for (final item in items) {
+      final cast = inner.get(model, key, item);
+      if (cast != null) result.add(cast);
+    }
+    return result;
+  }
+
+  @override
+  Object? set(Model model, String key, Object? value) {
+    if (value == null) return null;
+    if (value is List) {
+      final serialized = value
+          .map((item) => inner.set(model, key, item))
+          .toList();
+      return jsonEncode(serialized);
+    }
+    // Pass through raw storage forms (JSON string / single value).
+    return value;
+  }
+}

--- a/lib/src/database/eloquent/casts/list_cast.dart
+++ b/lib/src/database/eloquent/casts/list_cast.dart
@@ -7,13 +7,16 @@ import 'casts_attributes.dart';
 ///
 /// Storage form is a JSON-encoded string (so it survives SQLite TEXT columns
 /// and API round-trips). Reads accept either a `List` or a JSON string; writes
-/// always emit JSON.
+/// emit JSON when a `List` is provided and otherwise pass through raw storage
+/// forms unchanged.
 ///
 /// ```dart
+/// enum MonitorStatus { up, down, paused }
+///
 /// class Monitor extends Model {
 ///   @override
 ///   Map<String, dynamic> get casts => {
-///     'tags': ListCast(EnumCast(MonitorTag.values)),
+///     'statuses': ListCast(EnumCast(MonitorStatus.values)),
 ///   };
 /// }
 /// ```

--- a/lib/src/database/eloquent/model.dart
+++ b/lib/src/database/eloquent/model.dart
@@ -98,12 +98,12 @@ abstract class Model {
   ///
   /// Built-in cast types:
   /// - `datetime` → Carbon
-  /// - `json` → Map<String, dynamic>
+  /// - `json` → Map or List (whatever the stored JSON decodes to)
   /// - `bool` → bool
   /// - `int` → int
   /// - `double` → double
   ///
-  /// Class-based casts ship with Magic: [EnumCast], [ListCast]. Implement
+  /// Class-based casts ship with Magic: `EnumCast`, `ListCast`. Implement
   /// [CastsAttributes] to build your own.
   Map<String, dynamic> get casts => {};
 
@@ -170,8 +170,8 @@ abstract class Model {
         return value;
 
       case 'json':
-        if (value is Map) return value;
-        if (value is String) return jsonDecode(value) as Map<String, dynamic>;
+        if (value is Map || value is List) return value;
+        if (value is String) return jsonDecode(value);
         return value;
 
       case 'bool':
@@ -213,7 +213,7 @@ abstract class Model {
       _attributes[key] = Carbon.fromDateTime(
         value,
       ).format('yyyy-MM-ddTHH:mm:ss');
-    } else if (castType == 'json' && value is Map) {
+    } else if (castType == 'json' && (value is Map || value is List)) {
       _attributes[key] = jsonEncode(value);
     } else {
       _attributes[key] = value;

--- a/lib/src/database/eloquent/model.dart
+++ b/lib/src/database/eloquent/model.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import '../../support/carbon.dart';
+import 'casts/casts_attributes.dart';
 
 /// The base Eloquent Model.
 ///
@@ -92,13 +93,19 @@ abstract class Model {
 
   /// The attributes that should be cast.
   ///
-  /// Supported cast types:
+  /// Values can be either a string naming a built-in cast or an instance of
+  /// [CastsAttributes] for custom behaviour (enums, value objects, lists).
+  ///
+  /// Built-in cast types:
   /// - `datetime` → Carbon
   /// - `json` → Map<String, dynamic>
   /// - `bool` → bool
   /// - `int` → int
   /// - `double` → double
-  Map<String, String> get casts => {};
+  ///
+  /// Class-based casts ship with Magic: [EnumCast], [ListCast]. Implement
+  /// [CastsAttributes] to build your own.
+  Map<String, dynamic> get casts => {};
 
   /// The model relationships for automatic casting.
   ///
@@ -151,6 +158,10 @@ abstract class Model {
 
     if (value == null) return null;
 
+    if (castType is CastsAttributes) {
+      return castType.get(this, key, value);
+    }
+
     switch (castType) {
       case 'datetime':
         if (value is Carbon) return value;
@@ -189,6 +200,11 @@ abstract class Model {
   /// - [Map] values for json casts are encoded to strings
   void setAttribute(String key, dynamic value) {
     final castType = casts[key];
+
+    if (castType is CastsAttributes) {
+      _attributes[key] = castType.set(this, key, value);
+      return;
+    }
 
     // Convert types for storage
     if (value is Carbon) {

--- a/test/database/eloquent/casts_attributes_test.dart
+++ b/test/database/eloquent/casts_attributes_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+
+enum MonitorStatus { active, paused, failed }
+
+enum Tag { urgent, review, blocked }
+
+class _UpperCaseCast implements CastsAttributes<String> {
+  const _UpperCaseCast();
+
+  @override
+  String? get(Model model, String key, Object? raw) {
+    if (raw == null) return null;
+    return raw.toString().toUpperCase();
+  }
+
+  @override
+  Object? set(Model model, String key, Object? value) {
+    if (value is String) return value.toLowerCase();
+    return value;
+  }
+}
+
+class Monitor extends Model {
+  @override
+  String get table => 'monitors';
+
+  @override
+  String get resource => 'monitors';
+
+  @override
+  List<String> get fillable => ['status', 'tags', 'name'];
+
+  @override
+  Map<String, dynamic> get casts => {
+    'status': EnumCast(MonitorStatus.values),
+    'tags': ListCast(EnumCast(Tag.values)),
+    'name': const _UpperCaseCast(),
+  };
+
+  MonitorStatus? get status => getAttribute('status') as MonitorStatus?;
+  set status(MonitorStatus? value) => setAttribute('status', value);
+
+  List<Tag>? get tags => getAttribute('tags') as List<Tag>?;
+  set tags(List<Tag>? value) => setAttribute('tags', value);
+}
+
+class StrictMonitor extends Model {
+  @override
+  String get table => 'strict_monitors';
+
+  @override
+  String get resource => 'strict_monitors';
+
+  @override
+  Map<String, dynamic> get casts => {
+    'status': EnumCast(MonitorStatus.values, strict: true),
+  };
+}
+
+void main() {
+  group('EnumCast', () {
+    test('round-trips between enum and name', () {
+      final monitor = Monitor();
+      monitor.status = MonitorStatus.active;
+
+      expect(monitor.status, MonitorStatus.active);
+      expect(monitor.attributes['status'], 'active');
+    });
+
+    test('reads a raw name from storage as enum', () {
+      final monitor = Monitor();
+      monitor.setRawAttributes({'status': 'paused'});
+
+      expect(monitor.status, MonitorStatus.paused);
+    });
+
+    test('returns null for unknown value by default', () {
+      final monitor = Monitor();
+      monitor.setRawAttributes({'status': 'archived'});
+
+      expect(monitor.status, isNull);
+    });
+
+    test('throws on unknown value when strict', () {
+      final monitor = StrictMonitor();
+      monitor.setRawAttributes({'status': 'archived'});
+
+      expect(() => monitor.getAttribute('status'), throwsArgumentError);
+    });
+
+    test('null raw returns null', () {
+      final monitor = Monitor();
+      expect(monitor.status, isNull);
+    });
+
+    test('raw string passes through set() unchanged', () {
+      final monitor = Monitor();
+      monitor.setAttribute('status', 'failed');
+
+      expect(monitor.attributes['status'], 'failed');
+      expect(monitor.status, MonitorStatus.failed);
+    });
+  });
+
+  group('ListCast', () {
+    test('round-trips a list of enums via JSON', () {
+      final monitor = Monitor();
+      monitor.tags = [Tag.urgent, Tag.review];
+
+      expect(monitor.attributes['tags'], '["urgent","review"]');
+      expect(monitor.tags, [Tag.urgent, Tag.review]);
+    });
+
+    test('reads a JSON string from storage', () {
+      final monitor = Monitor();
+      monitor.setRawAttributes({'tags': '["blocked","urgent"]'});
+
+      expect(monitor.tags, [Tag.blocked, Tag.urgent]);
+    });
+
+    test('reads a raw list from storage', () {
+      final monitor = Monitor();
+      monitor.setRawAttributes({
+        'tags': ['review', 'blocked'],
+      });
+
+      expect(monitor.tags, [Tag.review, Tag.blocked]);
+    });
+
+    test('skips unknown values silently', () {
+      final monitor = Monitor();
+      monitor.setRawAttributes({
+        'tags': ['urgent', 'unknown', 'review'],
+      });
+
+      expect(monitor.tags, [Tag.urgent, Tag.review]);
+    });
+
+    test('null list returns null', () {
+      final monitor = Monitor();
+      expect(monitor.tags, isNull);
+    });
+  });
+
+  group('Custom CastsAttributes', () {
+    test('routes through custom get/set', () {
+      final monitor = Monitor();
+      monitor.setAttribute('name', 'Sentry');
+
+      // set() lowercased, get() uppercased.
+      expect(monitor.attributes['name'], 'sentry');
+      expect(monitor.getAttribute('name'), 'SENTRY');
+    });
+  });
+
+  group('Backwards compatibility', () {
+    test('string-based casts keep working', () {
+      final legacy = _LegacyModel();
+      legacy.setAttribute('flag', true);
+      expect(legacy.getAttribute('flag'), true);
+
+      legacy.setRawAttributes({'count': '42'});
+      expect(legacy.getAttribute('count'), 42);
+    });
+  });
+}
+
+class _LegacyModel extends Model {
+  @override
+  String get table => 'legacy';
+
+  @override
+  String get resource => 'legacy';
+
+  @override
+  Map<String, dynamic> get casts => {'flag': 'bool', 'count': 'int'};
+}

--- a/test/database/eloquent/model_test.dart
+++ b/test/database/eloquent/model_test.dart
@@ -125,6 +125,24 @@ void main() {
       expect(settings!['theme'], 'dark');
       expect(settings['notifications'], true);
     });
+
+    test('casts json decodes List storage to List', () {
+      final user = TestUser();
+      user.setAttribute('settings', '["a","b","c"]');
+
+      final decoded = user.getAttribute('settings');
+      expect(decoded, isA<List>());
+      expect(decoded, equals(['a', 'b', 'c']));
+    });
+
+    test('casts json encodes List values for storage', () {
+      final user = TestUser();
+      user.setAttribute('settings', ['x', 'y']);
+
+      final stored = user.attributes['settings'];
+      expect(stored, isA<String>());
+      expect(stored, '["x","y"]');
+    });
   });
 
   group('Model Dirty Checking', () {


### PR DESCRIPTION
## Summary
- Adds `CastsAttributes<T>` contract — models can register class-based casts alongside the existing string types.
- Ships `EnumCast<T extends Enum>` (with optional `strict` mode) and `ListCast<T>` (JSON-encoded element round-trip).
- Widens `Model.casts` to `Map<String, dynamic>`; subclasses returning `Map<String, String>` stay valid via covariant override.

Closes #71

## Test plan
- [x] `flutter test` — 939 tests pass (13 new in `casts_attributes_test.dart`)
- [x] `dart analyze` — no issues
- [x] `dart format .` — no changes
- [x] Enum round-trip, list round-trip, strict-mode throw, unknown-value null, raw-string pass-through, backwards compat with string casts