### PR TITLE
feat(validation): FormRequest abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ New Features
 - **Eloquent**: `Model.fill` now accepts a `strict` flag. When `true`, any non-fillable key throws `MassAssignmentException` instead of being silently dropped. Pair with validated request payloads to catch schema drift at the boundary. (#69)
+- **Validation**: `FormRequest` — Laravel-style request object that collapses authorize → prepare → validate into a single class. Throws `AuthorizationException` on denied access and `ValidationException` with a field-keyed error map on rule failure. Pairs with `Model.fill(validated, strict: true)`. (#66)
 
 ## [1.0.0-alpha.13] - 2026-04-16
 

--- a/doc/digging-deeper/validation.md
+++ b/doc/digging-deeper/validation.md
@@ -163,6 +163,50 @@ WFormInput(
 )
 ```
 
+<a name="form-request"></a>
+## Form Requests
+
+A `FormRequest` collapses "authorize, normalize, validate" into a single class so controllers stop hand-rolling that ceremony. Subclass `FormRequest`, implement `rules()`, optionally override `authorize()` and `prepared()`, then call `.validate(rawInput)`:
+
+```dart
+class StoreMonitorRequest extends FormRequest {
+  StoreMonitorRequest(this.actor);
+
+  final User actor;
+
+  @override
+  bool authorize() => actor.can('monitor.create');
+
+  @override
+  Map<String, dynamic> prepared(Map<String, dynamic> data) => {
+    ...data,
+    'slug': slugify(data['name'] as String? ?? ''),
+  };
+
+  @override
+  Map<String, List<Rule>> rules() => {
+    'name': [Required(), Max(120)],
+    'slug': [Required()],
+  };
+}
+
+// In the controller:
+try {
+  final payload = StoreMonitorRequest(Auth.user()!).validate(form.data);
+  await Http.post('/monitors', data: payload);
+} on AuthorizationException {
+  Magic.toast.error('You do not have permission to create monitors.');
+} on ValidationException catch (e) {
+  setFieldErrors(e.errors); // ValidatesRequests mixin
+}
+```
+
+- `authorize()` runs first and throws `AuthorizationException` on `false`.
+- `prepared()` normalizes the payload before rules see it (trim, slugify, merge defaults).
+- `validate()` returns the prepared payload filtered to the keys declared in `rules()` — same contract as `Validator.validate`.
+
+Pairs cleanly with `Model.fill(payload, strict: true)` so mass-assignment catches schema drift at the boundary.
+
 <a name="server-side-validation"></a>
 ## Server-Side Validation
 

--- a/lib/magic.dart
+++ b/lib/magic.dart
@@ -160,8 +160,10 @@ export 'src/validation/rules/confirmed.dart';
 export 'src/validation/rules/same.dart';
 export 'src/validation/rules/accepted.dart';
 export 'src/validation/exceptions/validation_exception.dart';
+export 'src/validation/exceptions/authorization_exception.dart';
 export 'src/validation/validator.dart';
 export 'src/validation/form_validator.dart';
+export 'src/validation/form_request.dart';
 export 'src/concerns/validates_requests.dart';
 
 // Events

--- a/lib/src/validation/exceptions/authorization_exception.dart
+++ b/lib/src/validation/exceptions/authorization_exception.dart
@@ -1,0 +1,14 @@
+/// Thrown when a [FormRequest.authorize] check (or a controller `authorize()`
+/// call) denies the current actor.
+///
+/// Apps typically catch this at the controller boundary and surface either a
+/// 403 page or a toast. The optional [message] lets you give the user a hint
+/// when the default "Unauthorized." feels too terse.
+class AuthorizationException implements Exception {
+  const AuthorizationException([this.message = 'Unauthorized.']);
+
+  final String message;
+
+  @override
+  String toString() => 'AuthorizationException: $message';
+}

--- a/lib/src/validation/form_request.dart
+++ b/lib/src/validation/form_request.dart
@@ -1,0 +1,72 @@
+import 'contracts/rule.dart';
+import 'exceptions/authorization_exception.dart';
+import 'validator.dart';
+
+/// Laravel-style request object — collapses the "authorize, normalize,
+/// validate" ceremony every controller hand-rolls into a single class.
+///
+/// Subclass [FormRequest], declare [rules], optionally override [authorize]
+/// for access checks and [prepared] for input normalization (trim, slugify,
+/// merge defaults). Pass the raw form payload to [validate] and it returns
+/// the prepared, rule-approved data:
+///
+/// ```dart
+/// class StoreMonitorRequest extends FormRequest {
+///   StoreMonitorRequest(this.actor);
+///
+///   final User actor;
+///
+///   @override
+///   bool authorize() => actor.can('monitor.create');
+///
+///   @override
+///   Map<String, dynamic> prepared(Map<String, dynamic> data) => {
+///     ...data,
+///     'slug': slugify(data['name'] as String? ?? ''),
+///   };
+///
+///   @override
+///   Map<String, List<Rule>> rules() => {
+///     'name': [Required(), Max(120)],
+///     'slug': [Required()],
+///   };
+/// }
+///
+/// // In the controller:
+/// final payload = StoreMonitorRequest(Auth.user()!).validate(form.data);
+/// await Http.post('/monitors', data: payload);
+/// ```
+///
+/// Failure modes:
+/// - [authorize] returns `false` → [AuthorizationException]
+/// - Any rule in [rules] fails → [ValidationException] with field-keyed map
+abstract class FormRequest {
+  const FormRequest();
+
+  /// The rules to apply to the prepared payload.
+  Map<String, List<Rule>> rules();
+
+  /// Authorization gate — override to return `false` to block the request.
+  bool authorize() => true;
+
+  /// Normalize the incoming payload before validation runs. Default is a
+  /// pass-through. Use this for trim/slugify/inject-defaults work so rules
+  /// always see consistent input.
+  Map<String, dynamic> prepared(Map<String, dynamic> data) => data;
+
+  /// Run authorize → prepare → validate. Returns the prepared payload,
+  /// filtered to the keys declared in [rules] (same contract as
+  /// `Validator.validate`).
+  ///
+  /// Throws:
+  /// - [AuthorizationException] when [authorize] returns `false`
+  /// - `ValidationException` when a rule fails
+  Map<String, dynamic> validate(Map<String, dynamic> data) {
+    if (!authorize()) {
+      throw const AuthorizationException();
+    }
+
+    final normalized = prepared(data);
+    return Validator.make(normalized, rules()).validate();
+  }
+}

--- a/test/validation/form_request_test.dart
+++ b/test/validation/form_request_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+
+class StoreMonitorRequest extends FormRequest {
+  StoreMonitorRequest({this.canCreate = true});
+
+  final bool canCreate;
+
+  @override
+  bool authorize() => canCreate;
+
+  @override
+  Map<String, dynamic> prepared(Map<String, dynamic> data) => {
+    ...data,
+    'name': (data['name'] as String?)?.trim(),
+  };
+
+  @override
+  Map<String, List<Rule>> rules() => {
+    'name': [Required(), Max(120)],
+    'email': [Required(), Email()],
+  };
+}
+
+void main() {
+  group('FormRequest.validate', () {
+    test('returns prepared payload when all rules pass', () {
+      final request = StoreMonitorRequest();
+      final payload = request.validate({
+        'name': '  Sentry  ',
+        'email': 'ops@example.com',
+      });
+
+      expect(payload['name'], 'Sentry');
+      expect(payload['email'], 'ops@example.com');
+    });
+
+    test('prepared() runs before rules', () {
+      final request = StoreMonitorRequest();
+
+      // Without trimming, rules would still pass because Max is inclusive,
+      // but prepared() should have normalized whitespace out.
+      final payload = request.validate({
+        'name': '   Hello   ',
+        'email': 'a@b.co',
+      });
+
+      expect(payload['name'], 'Hello');
+    });
+
+    test('throws AuthorizationException when authorize() returns false', () {
+      final request = StoreMonitorRequest(canCreate: false);
+
+      expect(
+        () => request.validate({'name': 'x', 'email': 'a@b.co'}),
+        throwsA(isA<AuthorizationException>()),
+      );
+    });
+
+    test('throws ValidationException on rule failure', () {
+      final request = StoreMonitorRequest();
+
+      try {
+        request.validate({'name': '', 'email': 'not-an-email'});
+        fail('expected ValidationException');
+      } on ValidationException catch (e) {
+        expect(e.errors.containsKey('name'), isTrue);
+        expect(e.errors.containsKey('email'), isTrue);
+      }
+    });
+
+    test('authorize check runs before validation', () {
+      // Bad data + unauthorized → authorize wins (short-circuit).
+      final request = StoreMonitorRequest(canCreate: false);
+
+      expect(
+        () => request.validate({'name': '', 'email': 'bad'}),
+        throwsA(isA<AuthorizationException>()),
+      );
+    });
+
+    test('payload is filtered to the keys declared in rules', () {
+      final request = StoreMonitorRequest();
+      final payload = request.validate({
+        'name': 'ok',
+        'email': 'a@b.co',
+        'extra': 'dropped',
+      });
+
+      expect(payload.containsKey('extra'), isFalse);
+    });
+
+    test('default authorize() returns true', () {
+      final request = _MinimalRequest();
+      expect(() => request.validate({'name': 'ok'}), returnsNormally);
+    });
+  });
+}
+
+class _MinimalRequest extends FormRequest {
+  @override
+  Map<String, List<Rule>> rules() => {
+    'name': [Required()],
+  };
+}


### PR DESCRIPTION
## Summary
- `FormRequest` abstract class with `rules()`, `authorize()`, `prepared()`, `validate(Map)` — Laravel-style collapse of authorize → prepare → validate.
- `AuthorizationException` thrown when `authorize()` returns false.
- `validate()` reuses `Validator.make().validate()` — returns the prepared payload filtered to declared keys, throws `ValidationException` on rule failure.

Closes #66

## Test plan
- [x] `flutter test` — 933 tests pass (7 new in `form_request_test.dart`)
- [x] `dart analyze` — no issues
- [x] `dart format .` — no changes
- [x] Covers: authorize short-circuit, prepared runs before rules, validation failure, payload filtering, default authorize true

## Follow-ups (not in this PR)
- `dart run magic:magic make:request` CLI generator lives in `magic_cli` — separate PR once the framework API ships