### PR TITLE
feat(http): add MagicController.authorize() helper (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### ✨ New Features
 - **Eloquent**: `Model.fill` now accepts a `strict` flag. When `true`, any non-fillable key throws `MassAssignmentException` instead of being silently dropped. Pair with validated request payloads to catch schema drift at the boundary. (#69)
 - **Validation**: `FormRequest` — Laravel-style request object that collapses authorize → prepare → validate into a single class. Throws `AuthorizationException` on denied access and `ValidationException` with a field-keyed error map on rule failure. Pairs with `Model.fill(validated, strict: true)`. (#66)
+- **HTTP**: `MagicController.authorize(ability, [arguments])`, a Laravel-style controller helper that delegates to `Gate.allows()` and throws `AuthorizationException` on denial. Avoids hand-rolling gate checks in every action. (#72)
+- **Auth**: `Gate.allowsAny(abilities, [arguments])` and `Gate.allowsAll(abilities, [arguments])`, short-circuiting sugar for checking multiple abilities at once. (#72)
 
 ## [1.0.0-alpha.13] - 2026-04-16
 

--- a/doc/security/authorization.md
+++ b/doc/security/authorization.md
@@ -95,7 +95,33 @@ if (Gate.denies('delete-post', post)) {
 if (Gate.check('view-admin')) {
   // Same as allows
 }
+
+// Any ability passes (short-circuits on first match)
+if (Gate.allowsAny(['owner', 'admin'], project)) {
+  // At least one ability allows access
+}
+
+// All abilities must pass (short-circuits on first failure)
+if (Gate.allowsAll(['update', 'publish'], post)) {
+  // Every ability allows access
+}
 ```
+
+### Inside Controllers
+
+`MagicController` exposes an `authorize()` helper that delegates to the Gate and throws `AuthorizationException` when access is denied. This mirrors Laravel's `$this->authorize()` inside controller actions:
+
+```dart
+class MonitorController extends MagicController with MagicStateMixin<Monitor> {
+  Future<void> update(String id, MonitorFormValues values) async {
+    final monitor = await Monitor.find(id);
+    authorize('update', monitor);
+    // ... proceed with update, exception already thrown on denial
+  }
+}
+```
+
+Catch `AuthorizationException` at the boundary (route handler, form submit) to surface a 403 view or feedback toast.
 
 <a name="super-admin-bypass"></a>
 ## Super Admin Bypass

--- a/lib/src/auth/gate_manager.dart
+++ b/lib/src/auth/gate_manager.dart
@@ -215,6 +215,34 @@ class GateManager {
     return allows(ability, arguments);
   }
 
+  /// Check if the authenticated user has any of the given abilities.
+  ///
+  /// Short-circuits on the first ability that passes.
+  ///
+  /// ```dart
+  /// if (Gate.allowsAny(['owner', 'admin'], project)) { ... }
+  /// ```
+  bool allowsAny(List<String> abilities, [dynamic arguments]) {
+    for (final ability in abilities) {
+      if (allows(ability, arguments)) return true;
+    }
+    return false;
+  }
+
+  /// Check if the authenticated user has every one of the given abilities.
+  ///
+  /// Short-circuits on the first ability that fails.
+  ///
+  /// ```dart
+  /// if (Gate.allowsAll(['update', 'publish'], post)) { ... }
+  /// ```
+  bool allowsAll(List<String> abilities, [dynamic arguments]) {
+    for (final ability in abilities) {
+      if (!allows(ability, arguments)) return false;
+    }
+    return true;
+  }
+
   /// Check if an ability has been defined.
   bool has(String ability) {
     return _abilities.containsKey(ability);

--- a/lib/src/facades/gate.dart
+++ b/lib/src/facades/gate.dart
@@ -101,6 +101,16 @@ class Gate {
     return _manager.check(ability, arguments);
   }
 
+  /// Returns `true` when any of [abilities] passes.
+  static bool allowsAny(List<String> abilities, [dynamic arguments]) {
+    return _manager.allowsAny(abilities, arguments);
+  }
+
+  /// Returns `true` only when every ability in [abilities] passes.
+  static bool allowsAll(List<String> abilities, [dynamic arguments]) {
+    return _manager.allowsAll(abilities, arguments);
+  }
+
   /// Check if an ability has been defined.
   static bool has(String ability) {
     return _manager.has(ability);

--- a/lib/src/http/magic_controller.dart
+++ b/lib/src/http/magic_controller.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:fluttersdk_wind/fluttersdk_wind.dart';
 
+import '../facades/gate.dart';
 import '../facades/http.dart';
+import '../validation/exceptions/authorization_exception.dart';
 import 'rx_status.dart';
 
 /// The Base Controller for Magic MVC.
@@ -63,6 +65,26 @@ abstract class MagicController extends ChangeNotifier {
   void refreshUI() {
     if (!_disposed) {
       notifyListeners();
+    }
+  }
+
+  /// Authorize an action against the current [Auth.user] via the [Gate].
+  ///
+  /// Mirrors Laravel's `$this->authorize('update', $model)` helper inside
+  /// controllers. Delegates to `Gate.allows(ability, arguments)`; on denial
+  /// it throws [AuthorizationException] so the caller can route to a 403
+  /// view or surface a feedback toast.
+  ///
+  /// ```dart
+  /// Future<Monitor?> update(String id, MonitorFormValues values) async {
+  ///   final monitor = await Monitor.find(id);
+  ///   authorize('update', monitor);
+  ///   ...
+  /// }
+  /// ```
+  void authorize(String ability, [Object? arguments]) {
+    if (!Gate.allows(ability, arguments)) {
+      throw AuthorizationException('This action is unauthorized: $ability');
     }
   }
 }

--- a/test/http/controller_authorize_test.dart
+++ b/test/http/controller_authorize_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+
+class _User extends Model with Authenticatable {
+  @override
+  String get table => 'users';
+
+  @override
+  String get resource => 'users';
+
+  @override
+  List<String> get fillable => ['id'];
+}
+
+class _PingController extends MagicController {
+  void ping(String ability, [Object? model]) => authorize(ability, model);
+}
+
+_User _makeUser() {
+  final user = _User();
+  user.fill({'id': 1});
+  user.exists = true;
+  return user;
+}
+
+void main() {
+  group('MagicController.authorize', () {
+    late _User actor;
+
+    setUp(() {
+      MagicApp.reset();
+      Magic.flush();
+      Gate.flush();
+      actor = _makeUser();
+      Auth.fake(user: actor);
+    });
+
+    tearDown(() => Auth.unfake());
+
+    test('passes through when gate allows', () {
+      Gate.define('update', (user, model) => true);
+      final controller = _PingController();
+
+      expect(() => controller.ping('update', 'x'), returnsNormally);
+    });
+
+    test('throws AuthorizationException when gate denies', () {
+      Gate.define('update', (user, model) => false);
+      final controller = _PingController();
+
+      expect(
+        () => controller.ping('update'),
+        throwsA(isA<AuthorizationException>()),
+      );
+    });
+
+    test('uses Auth.user() as the actor', () {
+      _User? seen;
+      Gate.define('update', (user, model) {
+        seen = user as _User;
+        return true;
+      });
+
+      _PingController().ping('update');
+      expect(seen, same(actor));
+    });
+
+    test('exception carries the ability name', () {
+      Gate.define('delete', (user, model) => false);
+      try {
+        _PingController().ping('delete');
+        fail('expected AuthorizationException');
+      } on AuthorizationException catch (e) {
+        expect(e.message, contains('delete'));
+      }
+    });
+  });
+
+  group('Gate sugar', () {
+    setUp(() {
+      MagicApp.reset();
+      Magic.flush();
+      Gate.flush();
+      Auth.fake(user: _makeUser());
+    });
+
+    tearDown(() => Auth.unfake());
+
+    test('allowsAny passes when one ability permits', () {
+      Gate.define('a', (_, _) => false);
+      Gate.define('b', (_, _) => true);
+      Gate.define('c', (_, _) => false);
+
+      expect(Gate.allowsAny(['a', 'b', 'c']), isTrue);
+    });
+
+    test('allowsAny fails when all deny', () {
+      Gate.define('a', (_, _) => false);
+      Gate.define('b', (_, _) => false);
+
+      expect(Gate.allowsAny(['a', 'b']), isFalse);
+    });
+
+    test('allowsAll passes only when every ability permits', () {
+      Gate.define('a', (_, _) => true);
+      Gate.define('b', (_, _) => true);
+
+      expect(Gate.allowsAll(['a', 'b']), isTrue);
+    });
+
+    test('allowsAll fails when any ability denies', () {
+      Gate.define('a', (_, _) => true);
+      Gate.define('b', (_, _) => false);
+
+      expect(Gate.allowsAll(['a', 'b']), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `MagicController.authorize(ability, [arguments])` — Laravel-style controller helper that delegates to `Gate.allows()` and throws `AuthorizationException` on denial.
- Add `Gate.allowsAny(abilities, [args])` and `Gate.allowsAll(abilities, [args])` sugar with short-circuit evaluation.
- Documentation and CHANGELOG updated.

Closes #72

## Test plan
- [x] `flutter test test/http/controller_authorize_test.dart` (8 tests pass)
- [x] `flutter test` (941 tests green)
- [x] `dart analyze` (no issues)
- [x] `dart format .`