### PR TITLE
feat(routing): add MagicRoute.resource() (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - **Validation**: `FormRequest` — Laravel-style request object that collapses authorize → prepare → validate into a single class. Throws `AuthorizationException` on denied access and `ValidationException` with a field-keyed error map on rule failure. Pairs with `Model.fill(validated, strict: true)`. (#66)
 - **HTTP**: `MagicController.authorize(ability, [arguments])`, a Laravel-style controller helper that delegates to `Gate.allows()` and throws `AuthorizationException` on denial. Avoids hand-rolling gate checks in every action. (#72)
 - **Auth**: `Gate.allowsAny(abilities, [arguments])` and `Gate.allowsAll(abilities, [arguments])`, short-circuiting sugar for checking multiple abilities at once. (#72)
+- **Routing**: `MagicRoute.resource(name, controller, {only, except})` auto-wires up to four canonical routes (index, create, show, edit) to a controller that mixes in `ResourceController`. Controllers declare supported methods via `resourceMethods`; `only` / `except` narrow the set further. Each route gets an auto-assigned `{slug}.{method}` name and title. (#67)
 
 ## [1.0.0-alpha.13] - 2026-04-16
 

--- a/doc/basics/routing.md
+++ b/doc/basics/routing.md
@@ -5,6 +5,7 @@
 - [Route Parameters](#route-parameters)
 - [Query Parameters](#query-parameters)
 - [Named Routes](#named-routes)
+- [Resource Routes](#resource-routes)
 - [Route Groups](#route-groups)
     - [Middleware](#middleware)
     - [Prefixes](#prefixes)
@@ -148,6 +149,70 @@ MagicRoute.toNamed('user.show', params: {'id': '42'});
 // With query parameters
 MagicRoute.toNamed('search', query: {'q': 'flutter'});
 ```
+
+<a name="resource-routes"></a>
+## Resource Routes
+
+`MagicRoute.resource()` wires the four canonical GET routes for a resource in a single line. The target controller must mix in `ResourceController` and implement the view-building methods it supports.
+
+| Path                 | Method       |
+| -------------------- | ------------ |
+| `/{name}`            | `index()`    |
+| `/{name}/create`     | `create()`   |
+| `/{name}/:id`        | `show(id)`   |
+| `/{name}/:id/edit`   | `edit(id)`   |
+
+```dart
+class MonitorController extends MagicController with ResourceController {
+  @override
+  Widget index() => const MonitorsIndexView();
+
+  @override
+  Widget create() => const MonitorCreateView();
+
+  @override
+  Widget show(String id) => MonitorShowView(id: id);
+
+  @override
+  Widget edit(String id) => MonitorEditView(id: id);
+}
+
+// Register all four routes at once
+MagicRoute.resource('monitors', MonitorController.instance);
+
+// Only a subset
+MagicRoute.resource(
+  'status-pages',
+  StatusPagesController.instance,
+  only: ['index', 'show'],
+);
+
+// All except a few
+MagicRoute.resource(
+  'metrics-library',
+  MetricsLibraryController.instance,
+  except: ['create', 'edit'],
+);
+```
+
+Controllers that only expose a subset can override `resourceMethods`:
+
+```dart
+class DocsController extends MagicController with ResourceController {
+  @override
+  Set<String> get resourceMethods => const {'index', 'show'};
+
+  @override
+  Widget index() => const DocsIndexView();
+
+  @override
+  Widget show(String id) => DocsShowView(slug: id);
+}
+```
+
+Each registered route receives the name and title key `{slug}.{method}` (for example `monitors.index`, `monitors.show`). Override with the usual fluent API when needed.
+
+Mutating actions (`store`, `update`, `destroy`) stay as regular controller methods invoked via `Http.post` / `put` / `delete`. They are not routes.
 
 <a name="route-groups"></a>
 ## Route Groups

--- a/lib/magic.dart
+++ b/lib/magic.dart
@@ -42,6 +42,7 @@ export 'src/helpers/date_helpers.dart';
 // Routing
 export 'src/routing/magic_router.dart';
 export 'src/routing/magic_router_outlet.dart';
+export 'src/routing/resource_controller.dart';
 export 'src/routing/route_definition.dart';
 export 'src/routing/title_manager.dart';
 

--- a/lib/src/facades/route.dart
+++ b/lib/src/facades/route.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
 import '../routing/magic_router.dart';
+import '../routing/resource_controller.dart';
 import '../routing/route_definition.dart';
 import '../routing/title_manager.dart';
 
@@ -183,6 +184,82 @@ class MagicRoute {
     final layout = LayoutDefinition(id: id, builder: builder, children: routes);
 
     MagicRouter.instance.addLayout(layout);
+  }
+
+  /// Register Laravel-style resource routes for a controller.
+  ///
+  /// Wires up to four canonical routes, scoped under `/{name}`:
+  ///
+  /// | Path                 | Method        |
+  /// | -------------------- | ------------- |
+  /// | `/{name}`            | `index()`     |
+  /// | `/{name}/create`     | `create()`    |
+  /// | `/{name}/:id`        | `show(id)`    |
+  /// | `/{name}/:id/edit`   | `edit(id)`    |
+  ///
+  /// Only methods declared in the controller's [ResourceController.resourceMethods]
+  /// set are registered. Use [only] or [except] to further filter the set.
+  ///
+  /// ```dart
+  /// MagicRoute.resource('monitors', MonitorController.instance);
+  /// MagicRoute.resource(
+  ///   'status-pages',
+  ///   StatusPagesController.instance,
+  ///   only: ['index', 'show'],
+  /// );
+  /// MagicRoute.resource(
+  ///   'metrics-library',
+  ///   MetricsLibraryController.instance,
+  ///   except: ['create', 'edit'],
+  /// );
+  /// ```
+  ///
+  /// Each route is auto-titled using the `{name}.{method}` translation key
+  /// pattern (e.g. `monitors.index`, `monitors.show`). Override with
+  /// `.title()` on the returned definitions if needed.
+  ///
+  /// Returns the list of registered [RouteDefinition]s in registration order.
+  static List<RouteDefinition> resource(
+    String name,
+    ResourceController controller, {
+    List<String>? only,
+    List<String>? except,
+  }) {
+    const allMethods = ['index', 'create', 'show', 'edit'];
+
+    final supported = controller.resourceMethods;
+    final onlySet = only?.toSet();
+    final exceptSet = except?.toSet() ?? const <String>{};
+
+    final selected = allMethods.where((method) {
+      if (!supported.contains(method)) return false;
+      if (onlySet != null && !onlySet.contains(method)) return false;
+      if (exceptSet.contains(method)) return false;
+      return true;
+    }).toList();
+
+    final slug = name.startsWith('/') ? name.substring(1) : name;
+    final registered = <RouteDefinition>[];
+
+    for (final method in selected) {
+      final RouteDefinition route;
+      switch (method) {
+        case 'index':
+          route = page('/$slug', controller.index);
+        case 'create':
+          route = page('/$slug/create', controller.create);
+        case 'show':
+          route = page('/$slug/:id', (String id) => controller.show(id));
+        case 'edit':
+          route = page('/$slug/:id/edit', (String id) => controller.edit(id));
+        default:
+          continue;
+      }
+      route.title('$slug.$method').name('$slug.$method');
+      registered.add(route);
+    }
+
+    return registered;
   }
 
   /// Combine parent and child prefixes.

--- a/lib/src/facades/route.dart
+++ b/lib/src/facades/route.dart
@@ -226,10 +226,32 @@ class MagicRoute {
     List<String>? except,
   }) {
     const allMethods = ['index', 'create', 'show', 'edit'];
+    const allMethodsSet = {'index', 'create', 'show', 'edit'};
 
     final supported = controller.resourceMethods;
     final onlySet = only?.toSet();
     final exceptSet = except?.toSet() ?? const <String>{};
+
+    // Reject unknown method names early so typos surface as errors,
+    // not silently dropped routes.
+    final unknownOnly = onlySet?.difference(allMethodsSet) ?? const <String>{};
+    if (unknownOnly.isNotEmpty) {
+      throw ArgumentError.value(
+        only,
+        'only',
+        'Unknown resource method(s): ${unknownOnly.join(', ')}. '
+            'Supported: ${allMethods.join(', ')}.',
+      );
+    }
+    final unknownExcept = exceptSet.difference(allMethodsSet);
+    if (unknownExcept.isNotEmpty) {
+      throw ArgumentError.value(
+        except,
+        'except',
+        'Unknown resource method(s): ${unknownExcept.join(', ')}. '
+            'Supported: ${allMethods.join(', ')}.',
+      );
+    }
 
     final selected = allMethods.where((method) {
       if (!supported.contains(method)) return false;
@@ -238,7 +260,11 @@ class MagicRoute {
       return true;
     }).toList();
 
-    final slug = name.startsWith('/') ? name.substring(1) : name;
+    // Normalize: collapse repeated slashes, trim leading/trailing.
+    final slug = name
+        .replaceAll(RegExp(r'/+'), '/')
+        .replaceFirst(RegExp(r'^/'), '')
+        .replaceFirst(RegExp(r'/$'), '');
     final registered = <RouteDefinition>[];
 
     for (final method in selected) {

--- a/lib/src/routing/resource_controller.dart
+++ b/lib/src/routing/resource_controller.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/widgets.dart';
+
+/// Contract for controllers that expose Laravel-style resource routes.
+///
+/// A resource controller declares up to four view-building methods that
+/// `MagicRoute.resource()` wires into canonical routes:
+///
+/// | Method          | Path                |
+/// | --------------- | ------------------- |
+/// | `index()`       | `GET /{resource}`        |
+/// | `create()`      | `GET /{resource}/create` |
+/// | `show(id)`      | `GET /{resource}/:id`    |
+/// | `edit(id)`      | `GET /{resource}/:id/edit` |
+///
+/// Controllers may override [resourceMethods] to expose only a subset.
+/// Non-exposed methods stay as `UnimplementedError` fallbacks.
+///
+/// ```dart
+/// class MonitorController extends MagicController with ResourceController {
+///   @override
+///   Widget index() => const MonitorsIndexView();
+///
+///   @override
+///   Widget show(String id) => MonitorShowView(id: id);
+///
+///   @override
+///   Set<String> get resourceMethods => const {'index', 'show'};
+/// }
+/// ```
+mixin ResourceController {
+  /// The set of resource methods this controller exposes. Defaults to all
+  /// four (`index`, `create`, `show`, `edit`). Override to limit registration.
+  Set<String> get resourceMethods => const {'index', 'create', 'show', 'edit'};
+
+  /// Render the collection view (`GET /{resource}`).
+  Widget index() =>
+      throw UnimplementedError('$runtimeType must override index()');
+
+  /// Render the create form (`GET /{resource}/create`).
+  Widget create() =>
+      throw UnimplementedError('$runtimeType must override create()');
+
+  /// Render a single resource (`GET /{resource}/:id`).
+  Widget show(String id) =>
+      throw UnimplementedError('$runtimeType must override show(id)');
+
+  /// Render the edit form (`GET /{resource}/:id/edit`).
+  Widget edit(String id) =>
+      throw UnimplementedError('$runtimeType must override edit(id)');
+}

--- a/test/routing/route_resource_test.dart
+++ b/test/routing/route_resource_test.dart
@@ -102,6 +102,39 @@ void main() {
       expect(routes.first.path, '/teams');
     });
 
+    test('normalizes trailing slash and repeated slashes', () {
+      final routes = MagicRoute.resource('/teams/', _FullController());
+
+      expect(routes.map((r) => r.path).toList(), [
+        '/teams',
+        '/teams/create',
+        '/teams/:id',
+        '/teams/:id/edit',
+      ]);
+
+      final nested = MagicRoute.resource('//admin//users//', _FullController());
+      expect(nested.first.path, '/admin/users');
+    });
+
+    test('throws on unknown method in only', () {
+      expect(
+        () => MagicRoute.resource(
+          'teams',
+          _FullController(),
+          only: ['index', 'destroy'],
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws on unknown method in except', () {
+      expect(
+        () =>
+            MagicRoute.resource('teams', _FullController(), except: ['store']),
+        throwsArgumentError,
+      );
+    });
+
     test('combines only and except', () {
       final routes = MagicRoute.resource(
         'posts',

--- a/test/routing/route_resource_test.dart
+++ b/test/routing/route_resource_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+
+class _FullController with ResourceController {
+  @override
+  Widget index() => const SizedBox.shrink();
+
+  @override
+  Widget create() => const SizedBox.shrink();
+
+  @override
+  Widget show(String id) => SizedBox.shrink(key: ValueKey('show-$id'));
+
+  @override
+  Widget edit(String id) => SizedBox.shrink(key: ValueKey('edit-$id'));
+}
+
+class _ReadOnlyController with ResourceController {
+  @override
+  Set<String> get resourceMethods => const {'index', 'show'};
+
+  @override
+  Widget index() => const SizedBox.shrink();
+
+  @override
+  Widget show(String id) => const SizedBox.shrink();
+}
+
+void main() {
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  setUp(() {
+    MagicApp.reset();
+    Magic.flush();
+    TitleManager.reset();
+    MagicRouter.reset();
+  });
+
+  group('MagicRoute.resource', () {
+    test('registers all four canonical routes by default', () {
+      final routes = MagicRoute.resource('monitors', _FullController());
+
+      expect(routes.map((r) => r.path).toList(), [
+        '/monitors',
+        '/monitors/create',
+        '/monitors/:id',
+        '/monitors/:id/edit',
+      ]);
+    });
+
+    test('assigns name and title from {slug}.{method}', () {
+      final routes = MagicRoute.resource('monitors', _FullController());
+
+      final index = routes.firstWhere((r) => r.path == '/monitors');
+      expect(index.routeName, 'monitors.index');
+      expect(index.routeTitle, 'monitors.index');
+
+      final show = routes.firstWhere((r) => r.path == '/monitors/:id');
+      expect(show.routeName, 'monitors.show');
+      expect(show.routeTitle, 'monitors.show');
+    });
+
+    test('only filters to the listed methods', () {
+      final routes = MagicRoute.resource(
+        'status-pages',
+        _FullController(),
+        only: ['index', 'create', 'show'],
+      );
+
+      expect(routes.map((r) => r.path).toList(), [
+        '/status-pages',
+        '/status-pages/create',
+        '/status-pages/:id',
+      ]);
+    });
+
+    test('except drops the listed methods', () {
+      final routes = MagicRoute.resource(
+        'metrics-library',
+        _FullController(),
+        except: ['create', 'edit'],
+      );
+
+      expect(routes.map((r) => r.path).toList(), [
+        '/metrics-library',
+        '/metrics-library/:id',
+      ]);
+    });
+
+    test('skips methods the controller does not expose', () {
+      final routes = MagicRoute.resource('docs', _ReadOnlyController());
+
+      expect(routes.map((r) => r.path).toList(), ['/docs', '/docs/:id']);
+    });
+
+    test('strips a leading slash from the resource name', () {
+      final routes = MagicRoute.resource('/teams', _FullController());
+
+      expect(routes.first.path, '/teams');
+    });
+
+    test('combines only and except', () {
+      final routes = MagicRoute.resource(
+        'posts',
+        _FullController(),
+        only: ['index', 'create', 'edit'],
+        except: ['create'],
+      );
+
+      expect(routes.map((r) => r.path).toList(), ['/posts', '/posts/:id/edit']);
+    });
+
+    test('registers routes with the MagicRouter', () {
+      MagicRoute.resource('monitors', _FullController(), only: ['index']);
+
+      final registered = MagicRouter.instance.routes;
+      expect(registered.any((r) => r.path == '/monitors'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `MagicRoute.resource(name, controller, {only, except})` that auto-wires up to four canonical GET routes (index, create, show, edit).
- Add `ResourceController` mixin: controllers declare supported methods via `resourceMethods` and implement view-building methods (`index()`, `create()`, `show(id)`, `edit(id)`).
- Each route gets auto-assigned `{slug}.{method}` name and title.
- Documentation and CHANGELOG updated.

Closes #67

## Test plan
- [x] `flutter test test/routing/route_resource_test.dart` (8 tests pass)
- [x] `flutter test` (934 tests green)
- [x] `dart analyze` (no issues)
- [x] `dart format .`