### PR TITLE
feat(validation): add async rules with Unique (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - **HTTP**: `MagicController.authorize(ability, [arguments])`, a Laravel-style controller helper that delegates to `Gate.allows()` and throws `AuthorizationException` on denial. Avoids hand-rolling gate checks in every action. (#72)
 - **Auth**: `Gate.allowsAny(abilities, [arguments])` and `Gate.allowsAll(abilities, [arguments])`, short-circuiting sugar for checking multiple abilities at once. (#72)
 - **Routing**: `MagicRoute.resource(name, controller, {only, except})` auto-wires up to four canonical routes (index, create, show, edit) to a controller that mixes in `ResourceController`. Controllers declare supported methods via `resourceMethods`; `only` / `except` narrow the set further. Each route gets an auto-assigned `{slug}.{method}` name and title. (#67)
+- **Validation**: `AsyncRule` contract plus `Unique(endpoint, field: ...)` rule, an async uniqueness check with per-instance debounce (coalesces rapid calls) and a pluggable `.via()` resolver. Network errors log and pass so they never block submission. `Validator.validateAsync()` runs async rules after sync rules; sync failures short-circuit per field. (#68)
 
 ## [1.0.0-alpha.13] - 2026-04-16
 

--- a/doc/digging-deeper/validation.md
+++ b/doc/digging-deeper/validation.md
@@ -267,6 +267,42 @@ if (controller.hasError('email'))
   WText(controller.getError('email')!, className: 'text-red-500 text-sm'),
 ```
 
+<a name="async-rules"></a>
+## Async Rules
+
+Some validations cannot decide locally: uniqueness, remote existence, captcha checks. Extend `AsyncRule` instead of `Rule` and implement `passesAsync`. Run the validator with `validateAsync()` to await async rules; sync failures short-circuit per field.
+
+```dart
+final validator = Validator.make(data, {
+  'slug': [Required(), Unique('/validate/unique', field: 'slug')],
+});
+
+try {
+  final validated = await validator.validateAsync();
+} on ValidationException catch (e) {
+  setFieldErrors(e.errors);
+}
+```
+
+### The Unique Rule
+
+`Unique(endpoint, field: ...)` issues a `GET` to the endpoint with `?{field}={value}` and treats `{"unique": true}` (or `{"available": true}`) as a pass. Network errors are logged and pass so a flaky connection never blocks the form; the server remains the source of truth on submit.
+
+```dart
+// Default HTTP resolver
+Unique('/validate/unique', field: 'slug');
+
+// Custom resolver
+Unique('/validate/unique', field: 'slug').via((endpoint, field, value) async {
+  final response = await Http.post(endpoint, data: {field: value});
+  return response.data?['unique'] == true;
+});
+```
+
+### Debounce
+
+`Unique` debounces rapid-fire calls (default 400ms). Only the last call within the window reaches the resolver; earlier calls resolve to `true` as stale. Pass `debounce: Duration.zero` to disable.
+
 <a name="custom-rules"></a>
 ## Custom Rules
 

--- a/doc/digging-deeper/validation.md
+++ b/doc/digging-deeper/validation.md
@@ -295,7 +295,7 @@ Unique('/validate/unique', field: 'slug');
 // Custom resolver
 Unique('/validate/unique', field: 'slug').via((endpoint, field, value) async {
   final response = await Http.post(endpoint, data: {field: value});
-  return response.data?['unique'] == true;
+  return response['unique'] == true;
 });
 ```
 

--- a/lib/magic.dart
+++ b/lib/magic.dart
@@ -153,6 +153,7 @@ export 'src/localization/localization_interceptor.dart';
 
 // Validation
 export 'src/validation/contracts/rule.dart';
+export 'src/validation/contracts/async_rule.dart';
 export 'src/validation/rules/required.dart';
 export 'src/validation/rules/email.dart';
 export 'src/validation/rules/min.dart';
@@ -160,6 +161,7 @@ export 'src/validation/rules/max.dart';
 export 'src/validation/rules/confirmed.dart';
 export 'src/validation/rules/same.dart';
 export 'src/validation/rules/accepted.dart';
+export 'src/validation/rules/unique.dart';
 export 'src/validation/exceptions/validation_exception.dart';
 export 'src/validation/exceptions/authorization_exception.dart';
 export 'src/validation/validator.dart';

--- a/lib/src/validation/contracts/async_rule.dart
+++ b/lib/src/validation/contracts/async_rule.dart
@@ -1,0 +1,43 @@
+import 'rule.dart';
+
+/// Contract for asynchronous validation rules.
+///
+/// Some rules cannot decide locally whether a value is valid. Uniqueness
+/// checks, remote existence lookups, or captcha verification all need an
+/// `await` before they can answer. `AsyncRule` extends [Rule] with a
+/// [passesAsync] method; the synchronous [passes] is a permissive
+/// placeholder that keeps sync-only validation flows working.
+///
+/// Validators that understand async rules should detect this subtype and
+/// `await` [passesAsync] instead of relying on [passes]. See
+/// [Validator.validateAsync].
+///
+/// ```dart
+/// class Exists extends AsyncRule {
+///   Exists(this.endpoint);
+///   final String endpoint;
+///
+///   @override
+///   Future<bool> passesAsync(String attr, value, Map<String, dynamic> data) async {
+///     final response = await Http.get(endpoint, query: {attr: value?.toString() ?? ''});
+///     return response.successful;
+///   }
+///
+///   @override
+///   String message() => 'validation.exists';
+/// }
+/// ```
+abstract class AsyncRule extends Rule {
+  /// Asynchronously determine if the rule passes.
+  Future<bool> passesAsync(
+    String attribute,
+    dynamic value,
+    Map<String, dynamic> data,
+  );
+
+  /// Synchronous fallback. Async rules pass sync validation unconditionally so
+  /// the async pass can report the real outcome.
+  @override
+  bool passes(String attribute, dynamic value, Map<String, dynamic> data) =>
+      true;
+}

--- a/lib/src/validation/contracts/async_rule.dart
+++ b/lib/src/validation/contracts/async_rule.dart
@@ -18,7 +18,7 @@ import 'rule.dart';
 ///   final String endpoint;
 ///
 ///   @override
-///   Future<bool> passesAsync(String attr, value, Map<String, dynamic> data) async {
+///   Future<bool> passesAsync(String attr, dynamic value, Map<String, dynamic> data) async {
 ///     final response = await Http.get(endpoint, query: {attr: value?.toString() ?? ''});
 ///     return response.successful;
 ///   }

--- a/lib/src/validation/rules/unique.dart
+++ b/lib/src/validation/rules/unique.dart
@@ -1,0 +1,122 @@
+import '../../facades/http.dart';
+import '../../facades/log.dart';
+import '../contracts/async_rule.dart';
+
+/// Resolver signature for async uniqueness lookups.
+///
+/// Given the [endpoint], [field], and [value], return `true` if the value is
+/// unique (available) and `false` if it is already taken.
+typedef UniqueResolver =
+    Future<bool> Function(String endpoint, String field, dynamic value);
+
+/// Asynchronously validates that a value is unique by hitting a backend
+/// endpoint.
+///
+/// The default resolver issues `GET {endpoint}?{field}={value}` and treats a
+/// `{"unique": true}` (or `{"available": true}`) response body as a pass.
+/// Network errors are logged and treated as passes so they never block form
+/// submission; the authoritative check still happens on the server.
+///
+/// ```dart
+/// Validator.make(data, {
+///   'slug': [Required(), Unique('/validate/unique', field: 'slug')],
+/// }).validateAsync();
+/// ```
+///
+/// ## Debounce
+///
+/// Rapid-fire calls (typing into a field with `autovalidate`) are coalesced
+/// via a per-instance debounce window. Only the last call within the window
+/// actually reaches the resolver; earlier calls resolve to `true` (stale) and
+/// never record errors. Set [debounce] to [Duration.zero] to disable.
+///
+/// ## Custom Resolver
+///
+/// Override the HTTP call shape with [via]:
+///
+/// ```dart
+/// Unique('/validate/unique', field: 'slug').via((endpoint, field, value) async {
+///   final response = await Http.post(endpoint, data: {field: value});
+///   return response.data?['unique'] == true;
+/// });
+/// ```
+class Unique extends AsyncRule {
+  Unique(
+    this.endpoint, {
+    required this.field,
+    this.debounce = const Duration(milliseconds: 400),
+  });
+
+  /// The endpoint to query.
+  final String endpoint;
+
+  /// The field name reported to the endpoint.
+  final String field;
+
+  /// Debounce window. Duration.zero disables debouncing.
+  final Duration debounce;
+
+  UniqueResolver? _resolver;
+
+  int _token = 0;
+
+  /// Swap the default HTTP resolver for a custom one.
+  Unique via(UniqueResolver resolver) {
+    _resolver = resolver;
+    return this;
+  }
+
+  @override
+  Future<bool> passesAsync(
+    String attribute,
+    dynamic value,
+    Map<String, dynamic> data,
+  ) async {
+    final token = ++_token;
+
+    if (debounce > Duration.zero) {
+      await Future<void>.delayed(debounce);
+      if (token != _token) {
+        // A later call superseded this one while we were waiting. Treat as
+        // a pass so this stale check never records an error.
+        return true;
+      }
+    }
+
+    final resolver = _resolver ?? _defaultResolver;
+
+    try {
+      return await resolver(endpoint, field, value);
+    } catch (error) {
+      Log.error('Unique rule network error', error);
+      return true;
+    }
+  }
+
+  Future<bool> _defaultResolver(
+    String endpoint,
+    String field,
+    dynamic value,
+  ) async {
+    final response = await Http.get(
+      endpoint,
+      query: {field: value?.toString() ?? ''},
+    );
+
+    if (response.failed) {
+      // Treat transport failures as valid; server-side validation is the
+      // source of truth for uniqueness.
+      return true;
+    }
+
+    final body = response.data;
+    if (body is Map<String, dynamic>) {
+      return body['unique'] == true || body['available'] == true;
+    }
+
+    return true;
+  }
+
+  @override
+  String message() => 'validation.unique';
+}

--- a/lib/src/validation/rules/unique.dart
+++ b/lib/src/validation/rules/unique.dart
@@ -18,9 +18,11 @@ typedef UniqueResolver =
 /// submission; the authoritative check still happens on the server.
 ///
 /// ```dart
-/// Validator.make(data, {
-///   'slug': [Required(), Unique('/validate/unique', field: 'slug')],
-/// }).validateAsync();
+/// Future<void> submit() async {
+///   await Validator.make(data, {
+///     'slug': [Required(), Unique('/validate/unique', field: 'slug')],
+///   }).validateAsync();
+/// }
 /// ```
 ///
 /// ## Debounce
@@ -37,7 +39,7 @@ typedef UniqueResolver =
 /// ```dart
 /// Unique('/validate/unique', field: 'slug').via((endpoint, field, value) async {
 ///   final response = await Http.post(endpoint, data: {field: value});
-///   return response.data?['unique'] == true;
+///   return response['unique'] == true;
 /// });
 /// ```
 class Unique extends AsyncRule {
@@ -72,6 +74,11 @@ class Unique extends AsyncRule {
     dynamic value,
     Map<String, dynamic> data,
   ) async {
+    // Presence is `Required`'s job — skip null/empty so optional fields never
+    // trigger a network call or report a false uniqueness failure.
+    if (value == null) return true;
+    if (value is String && value.trim().isEmpty) return true;
+
     final token = ++_token;
 
     if (debounce > Duration.zero) {
@@ -86,7 +93,12 @@ class Unique extends AsyncRule {
     final resolver = _resolver ?? _defaultResolver;
 
     try {
-      return await resolver(endpoint, field, value);
+      final result = await resolver(endpoint, field, value);
+      // Re-check the token after awaiting: a later call may have superseded
+      // this one while the resolver was in flight. Stale results must not
+      // record an error.
+      if (token != _token) return true;
+      return result;
     } catch (error) {
       Log.error('Unique rule network error', error);
       return true;

--- a/lib/src/validation/validator.dart
+++ b/lib/src/validation/validator.dart
@@ -1,4 +1,5 @@
 import '../facades/lang.dart';
+import 'contracts/async_rule.dart';
 import 'contracts/rule.dart';
 import 'exceptions/validation_exception.dart';
 
@@ -112,7 +113,50 @@ class Validator {
       throw ValidationException(_errors);
     }
 
-    // Return only the validated fields (Laravel behavior)
+    return _collectValidated();
+  }
+
+  /// Run validation including any [AsyncRule]s and throw if it fails.
+  ///
+  /// Synchronous rules run first (short-circuit per field on first failure).
+  /// Async rules then run only for fields that passed synchronous rules and
+  /// do not yet have an error. Returns the validated data on success.
+  ///
+  /// ```dart
+  /// try {
+  ///   final validated = await validator.validateAsync();
+  /// } on ValidationException catch (e) {
+  ///   print(e.errors);
+  /// }
+  /// ```
+  Future<Map<String, dynamic>> validateAsync() async {
+    if (!_hasRun) {
+      _runValidation();
+    }
+
+    for (final entry in _rules.entries) {
+      final attribute = entry.key;
+      if (_errors.containsKey(attribute)) continue;
+
+      final value = _data[attribute];
+      for (final rule in entry.value) {
+        if (rule is! AsyncRule) continue;
+        final passed = await rule.passesAsync(attribute, value, _data);
+        if (!passed) {
+          _errors[attribute] = _resolveMessage(rule, attribute);
+          break;
+        }
+      }
+    }
+
+    if (_errors.isNotEmpty) {
+      throw ValidationException(_errors);
+    }
+
+    return _collectValidated();
+  }
+
+  Map<String, dynamic> _collectValidated() {
     final validated = <String, dynamic>{};
     for (final key in _rules.keys) {
       if (_data.containsKey(key)) {

--- a/test/validation/unique_rule_test.dart
+++ b/test/validation/unique_rule_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+
+void main() {
+  group('Unique rule (async)', () {
+    test('passes when resolver reports unique', () async {
+      final rule = Unique(
+        '/validate/unique',
+        field: 'slug',
+        debounce: Duration.zero,
+      ).via((_, _, _) async => true);
+
+      final validator = Validator.make(
+        {'slug': 'my-page'},
+        {
+          'slug': [rule],
+        },
+      );
+
+      final validated = await validator.validateAsync();
+      expect(validated, {'slug': 'my-page'});
+    });
+
+    test('fails when resolver reports taken', () async {
+      final rule = Unique(
+        '/validate/unique',
+        field: 'slug',
+        debounce: Duration.zero,
+      ).via((_, _, _) async => false);
+
+      final validator = Validator.make(
+        {'slug': 'taken'},
+        {
+          'slug': [rule],
+        },
+      );
+
+      await expectLater(
+        validator.validateAsync(),
+        throwsA(isA<ValidationException>()),
+      );
+      expect(validator.errors().keys, contains('slug'));
+    });
+
+    test('passes on network error and logs', () async {
+      Log.fake();
+      final rule = Unique(
+        '/validate/unique',
+        field: 'slug',
+        debounce: Duration.zero,
+      ).via((_, _, _) async => throw Exception('boom'));
+
+      final validator = Validator.make(
+        {'slug': 'x'},
+        {
+          'slug': [rule],
+        },
+      );
+
+      final validated = await validator.validateAsync();
+      expect(validated, {'slug': 'x'});
+      Log.unfake();
+    });
+
+    test('sync rules short-circuit async rules', () async {
+      var called = false;
+      final unique =
+          Unique(
+            '/validate/unique',
+            field: 'slug',
+            debounce: Duration.zero,
+          ).via((_, _, _) async {
+            called = true;
+            return true;
+          });
+
+      final validator = Validator.make(
+        {'slug': ''},
+        {
+          'slug': [Required(), unique],
+        },
+      );
+
+      await expectLater(
+        validator.validateAsync(),
+        throwsA(isA<ValidationException>()),
+      );
+      expect(called, isFalse, reason: 'Required must short-circuit Unique');
+    });
+
+    test('debounce coalesces rapid calls (stale calls pass)', () async {
+      var calls = 0;
+      final rule =
+          Unique(
+            '/validate/unique',
+            field: 'slug',
+            debounce: const Duration(milliseconds: 50),
+          ).via((_, _, value) async {
+            calls++;
+            return value != 'taken';
+          });
+
+      final first = rule.passesAsync('slug', 'a', {});
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      final second = rule.passesAsync('slug', 'b', {});
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      final third = rule.passesAsync('slug', 'taken', {});
+
+      final results = await Future.wait([first, second, third]);
+
+      expect(calls, 1, reason: 'Only the last call should reach the resolver');
+      expect(results[0], isTrue, reason: 'stale');
+      expect(results[1], isTrue, reason: 'stale');
+      expect(results[2], isFalse, reason: 'last call resolved with "taken"');
+    });
+
+    test('default resolver treats {"unique": true} as pass', () async {
+      Http.fake({
+        '/validate/unique*': Http.response({'unique': true}),
+      });
+      final rule = Unique(
+        '/validate/unique',
+        field: 'slug',
+        debounce: Duration.zero,
+      );
+
+      expect(await rule.passesAsync('slug', 'available', {}), isTrue);
+      Http.unfake();
+    });
+
+    test('default resolver treats {"unique": false} as fail', () async {
+      Http.fake({
+        '/validate/unique*': Http.response({'unique': false}),
+      });
+      final rule = Unique(
+        '/validate/unique',
+        field: 'slug',
+        debounce: Duration.zero,
+      );
+
+      expect(await rule.passesAsync('slug', 'taken', {}), isFalse);
+      Http.unfake();
+    });
+  });
+}

--- a/test/validation/unique_rule_test.dart
+++ b/test/validation/unique_rule_test.dart
@@ -43,7 +43,7 @@ void main() {
     });
 
     test('passes on network error and logs', () async {
-      Log.fake();
+      final log = Log.fake();
       final rule = Unique(
         '/validate/unique',
         field: 'slug',
@@ -59,7 +59,62 @@ void main() {
 
       final validated = await validator.validateAsync();
       expect(validated, {'slug': 'x'});
+      log.assertLoggedError('Unique rule network error');
       Log.unfake();
+    });
+
+    test(
+      'passes without calling resolver when value is null or empty',
+      () async {
+        var called = false;
+        final rule =
+            Unique(
+              '/validate/unique',
+              field: 'slug',
+              debounce: Duration.zero,
+            ).via((_, _, _) async {
+              called = true;
+              return false;
+            });
+
+        expect(await rule.passesAsync('slug', null, {}), isTrue);
+        expect(await rule.passesAsync('slug', '', {}), isTrue);
+        expect(await rule.passesAsync('slug', '   ', {}), isTrue);
+        expect(
+          called,
+          isFalse,
+          reason: 'Resolver must not run for empty input',
+        );
+      },
+    );
+
+    test('stale resolver result after debounce is discarded', () async {
+      var slowCompleter = 0;
+      final rule =
+          Unique(
+            '/validate/unique',
+            field: 'slug',
+            debounce: const Duration(milliseconds: 10),
+          ).via((_, _, value) async {
+            slowCompleter++;
+            // First (stale) call has a long resolver; second (fresh) call is
+            // fast and should win the race.
+            if (value == 'stale') {
+              await Future<void>.delayed(const Duration(milliseconds: 100));
+              return false;
+            }
+            return true;
+          });
+
+      final stale = rule.passesAsync('slug', 'stale', {});
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      final fresh = rule.passesAsync('slug', 'fresh', {});
+
+      final results = await Future.wait([stale, fresh]);
+
+      expect(slowCompleter, 2, reason: 'Both resolvers were dispatched');
+      expect(results[0], isTrue, reason: 'Stale in-flight result is discarded');
+      expect(results[1], isTrue);
     });
 
     test('sync rules short-circuit async rules', () async {


### PR DESCRIPTION
## Summary
- Add `AsyncRule` contract; `Unique(endpoint, field)` rule with debounce + `.via()` resolver.
- Add `Validator.validateAsync()` that runs sync rules first (short-circuit per field), then awaits any async rules.
- Network errors inside Unique are logged and pass — server-side validation remains the source of truth on submit.
- Documentation and CHANGELOG updated.

Closes #68

## Test plan
- [x] `flutter test test/validation/unique_rule_test.dart` (7 tests pass)
- [x] `flutter test` (933 tests green)
- [x] `dart analyze` (no issues)
- [x] `dart format .`