### PR TITLE
feat(session): add Session facade with flash data + auto-flash on form validation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - **Auth**: `Gate.allowsAny(abilities, [arguments])` and `Gate.allowsAll(abilities, [arguments])`, short-circuiting sugar for checking multiple abilities at once. (#72)
 - **Routing**: `MagicRoute.resource(name, controller, {only, except})` auto-wires up to four canonical routes (index, create, show, edit) to a controller that mixes in `ResourceController`. Controllers declare supported methods via `resourceMethods`; `only` / `except` narrow the set further. Each route gets an auto-assigned `{slug}.{method}` name and title. (#67)
 - **Validation**: `AsyncRule` contract plus `Unique(endpoint, field: ...)` rule, an async uniqueness check with per-instance debounce (coalesces rapid calls) and a pluggable `.via()` resolver. Network errors log and pass so they never block submission. `Validator.validateAsync()` runs async rules after sync rules; sync failures short-circuit per field. (#68)
+- **Session**: Add `Session` facade with Laravel-style flash data — `Session.flash(data)`, `Session.flashErrors(errors)`, `Session.old(field, [fallback])`, `Session.error(field)`, `Session.errors(field)`, `Session.hasError(field)`, `Session.hasFlash`, `Session.tick()`. Two-bucket store promotes flashed data exactly one navigation hop so forms can repopulate after a failed submit. Top-level helpers `old()` and `error()` mirror Laravel's Blade API
+- **UI**: `MagicFormData.validate()` automatically flashes form data on validation failure — downstream views can repopulate via `old('field')` without manual wiring
 
 ## [1.0.0-alpha.13] - 2026-04-16
 

--- a/doc/digging-deeper/session.md
+++ b/doc/digging-deeper/session.md
@@ -1,0 +1,96 @@
+# Session & Flash Data
+
+- [Introduction](#introduction)
+- [Flashing Input](#flashing-input)
+- [Flashing Errors](#flashing-errors)
+- [Reading Old Input](#reading-old-input)
+- [Automatic Flash in MagicFormData](#automatic-flash-in-magicformdata)
+- [Advancing the Flash Bucket](#advancing-the-flash-bucket)
+- [Testing](#testing)
+
+<a name="introduction"></a>
+## Introduction
+
+The `Session` facade provides Laravel-style flash data that survives exactly one navigation hop. Use it to repopulate a form after a failed submit and a back navigation without wiring temporary state through controllers, the router, or global singletons.
+
+The store has two buckets: the **current** bucket (readable by the view being built right now) and the **next** bucket (being collected by the currently-active handler). A call to `Session.tick()` promotes `next` into `current`, so flashed data is visible on exactly one frame.
+
+<a name="flashing-input"></a>
+## Flashing Input
+
+Flash a map of values before navigating away:
+
+```dart
+Session.flash({
+  'name': 'John',
+  'email': 'john@test.com',
+});
+MagicRoute.back();
+```
+
+<a name="flashing-errors"></a>
+## Flashing Errors
+
+Flash per-field error messages:
+
+```dart
+Session.flashErrors({
+  'email': ['The email has already been taken.'],
+});
+```
+
+<a name="reading-old-input"></a>
+## Reading Old Input
+
+In the form view, repopulate via the `old()` helper:
+
+```dart
+WFormInput(
+  initialValue: old('email') ?? '',
+);
+
+if (Session.hasError('email'))
+  WText(Session.error('email')!, className: 'text-red-500');
+```
+
+`Session.oldRaw(field)` returns the original typed value (booleans, numbers, custom objects) instead of stringifying it.
+
+<a name="automatic-flash-in-magicformdata"></a>
+## Automatic Flash in MagicFormData
+
+`MagicFormData.validate()` automatically flashes the current form data when validation fails, so you never need to wire it manually:
+
+```dart
+void _submit() {
+  if (!form.validate()) return; // form data is auto-flashed on failure
+  controller.register(form.data);
+}
+```
+
+After a back navigation and a `Session.tick()`, `old('email')` returns the last-submitted value.
+
+<a name="advancing-the-flash-bucket"></a>
+## Advancing the Flash Bucket
+
+Flash data survives exactly one navigation. Advance the bucket on every route change by wiring `Session.tick` to the router delegate once:
+
+```dart
+MagicRouter.instance.routerConfig.routerDelegate.addListener(Session.tick);
+```
+
+Place this in a `ServiceProvider.boot()` after `Magic.init()` completes.
+
+<a name="testing"></a>
+## Testing
+
+In tests, always reset the store in `setUp()`:
+
+```dart
+setUp(() {
+  MagicApp.reset();
+  Magic.flush();
+  Session.reset();
+});
+```
+
+Swap the backing store with a custom `SessionStore` via `Session.setStore(store)` if you need isolated buckets per test group.

--- a/doc/digging-deeper/session.md
+++ b/doc/digging-deeper/session.md
@@ -72,10 +72,17 @@ After a back navigation and a `Session.tick()`, `old('email')` returns the last-
 <a name="advancing-the-flash-bucket"></a>
 ## Advancing the Flash Bucket
 
-Flash data survives exactly one navigation. Advance the bucket on every route change by wiring `Session.tick` to the router delegate once:
+Flash data survives exactly one navigation. Advance the bucket only when the router location actually changes. Do **not** wire `Session.tick` directly to the router delegate listener: the delegate can notify for more than real navigation (redirect re-evaluation, notifier rebuilds) and would expire flash data prematurely.
 
 ```dart
-MagicRouter.instance.routerConfig.routerDelegate.addListener(Session.tick);
+var lastLocation = MagicRouter.instance.currentLocation;
+
+MagicRouter.instance.routerConfig.routerDelegate.addListener(() {
+  final currentLocation = MagicRouter.instance.currentLocation;
+  if (currentLocation == lastLocation) return;
+  lastLocation = currentLocation;
+  Session.tick();
+});
 ```
 
 Place this in a `ServiceProvider.boot()` after `Magic.init()` completes.

--- a/lib/magic.dart
+++ b/lib/magic.dart
@@ -193,6 +193,10 @@ export 'src/storage/magic_file_extensions.dart';
 export 'src/facades/storage.dart';
 export 'src/facades/pick.dart';
 
+// Session
+export 'src/session/session_store.dart';
+export 'src/facades/session.dart';
+
 // Authorization (Gate)
 export 'src/auth/gate_manager.dart';
 export 'src/facades/gate.dart';

--- a/lib/src/facades/session.dart
+++ b/lib/src/facades/session.dart
@@ -21,8 +21,19 @@ import '../session/session_store.dart';
 /// ```
 ///
 /// Flash data survives exactly one navigation. Call [Session.tick] on every
-/// route change to advance the bucket. Wire this via your preferred router
-/// listener (e.g. `MagicRouter.instance.routerConfig.routerDelegate.addListener(Session.tick)`).
+/// real route change. The router delegate listener can fire for non-navigation
+/// events (redirect re-evaluation, notifier rebuilds), so gate the tick on an
+/// actual location change:
+///
+/// ```dart
+/// var lastLocation = MagicRouter.instance.currentLocation;
+/// MagicRouter.instance.routerConfig.routerDelegate.addListener(() {
+///   final currentLocation = MagicRouter.instance.currentLocation;
+///   if (currentLocation == lastLocation) return;
+///   lastLocation = currentLocation;
+///   Session.tick();
+/// });
+/// ```
 class Session {
   Session._();
 

--- a/lib/src/facades/session.dart
+++ b/lib/src/facades/session.dart
@@ -1,0 +1,85 @@
+import '../session/session_store.dart';
+
+/// The Session Facade.
+///
+/// Provides a Laravel-style flash-data API for surviving navigation: flash
+/// input on failed submit, navigate back, repopulate the form with
+/// [Session.old] / [Session.error].
+///
+/// ```dart
+/// // On failed submit:
+/// Session.flash(form.data);
+/// Session.flashErrors({'email': ['Invalid email.']});
+/// MagicRoute.back();
+///
+/// // In the form view:
+/// WFormInput(
+///   initialValue: Session.old('email') ?? '',
+/// );
+/// if (Session.hasError('email'))
+///   WText(Session.error('email')!, className: 'text-red-500');
+/// ```
+///
+/// Flash data survives exactly one navigation. Call [Session.tick] on every
+/// route change to advance the bucket. Wire this via your preferred router
+/// listener (e.g. `MagicRouter.instance.routerConfig.routerDelegate.addListener(Session.tick)`).
+class Session {
+  Session._();
+
+  static SessionStore _store = SessionStore();
+
+  /// The underlying store. Exposed for testing.
+  static SessionStore get store => _store;
+
+  /// Flash input values for the next frame.
+  static void flash(Map<String, dynamic> input) => _store.flash(input);
+
+  /// Flash validation errors for the next frame.
+  static void flashErrors(Map<String, List<String>> errors) =>
+      _store.flashErrors(errors);
+
+  /// Read a flashed input value as a string.
+  static String? old(String field, [String? fallback]) =>
+      _store.old(field, fallback);
+
+  /// Read a flashed input value in its original type.
+  static dynamic oldRaw(String field) => _store.oldRaw(field);
+
+  /// Read the first flashed error for a field.
+  static String? error(String field) => _store.error(field);
+
+  /// Read all flashed errors for a field.
+  static List<String> errors(String field) => _store.errors(field);
+
+  /// Whether the given field has a flashed error.
+  static bool hasError(String field) => _store.hasError(field);
+
+  /// Whether any flashed input or error is readable.
+  static bool get hasFlash => _store.hasFlash;
+
+  /// Advance the flash bucket. Call on every navigation.
+  static void tick() => _store.tick();
+
+  /// Wipe both buckets. Intended for tests.
+  static void reset() => _store.reset();
+
+  /// Swap the underlying store (for testing).
+  static void setStore(SessionStore store) {
+    _store = store;
+  }
+
+  /// Top-level helper equivalent to [old].
+  // Kept here to avoid a second public class.
+  static String? oldInput(String field, [String? fallback]) =>
+      old(field, fallback);
+}
+
+/// Top-level helper, mirrors Laravel's `old()`.
+///
+/// ```dart
+/// WFormInput(initialValue: old('email') ?? '');
+/// ```
+String? old(String field, [String? fallback]) => Session.old(field, fallback);
+
+/// Top-level helper, mirrors Laravel's `$errors->first('field')`.
+String? error(String field) => Session.error(field);

--- a/lib/src/session/session_store.dart
+++ b/lib/src/session/session_store.dart
@@ -28,9 +28,14 @@ class SessionStore {
   }
 
   /// Read a flashed input value.
+  ///
+  /// Returns [fallback] only when the key was never flashed. An explicitly
+  /// flashed `null` returns `null` so callers can distinguish "unset" from
+  /// "set to null".
   String? old(String field, [String? fallback]) {
+    if (!_current.containsKey(field)) return fallback;
     final value = _current[field];
-    if (value == null) return fallback;
+    if (value == null) return null;
     return value.toString();
   }
 
@@ -52,7 +57,13 @@ class SessionStore {
   bool get hasFlash => _current.isNotEmpty || _currentErrors.isNotEmpty;
 
   /// Whether a field has a flashed error.
-  bool hasError(String field) => _currentErrors.containsKey(field);
+  ///
+  /// Returns `true` only when at least one error message is present, keeping
+  /// behavior aligned with [error] (which returns `null` for empty lists).
+  bool hasError(String field) {
+    final list = _currentErrors[field];
+    return list != null && list.isNotEmpty;
+  }
 
   /// Advance the flash bucket: promote `_next` to `_current`, clear `_next`.
   /// Call on every navigation to make flashed data survive exactly one hop.

--- a/lib/src/session/session_store.dart
+++ b/lib/src/session/session_store.dart
@@ -1,0 +1,73 @@
+/// In-memory session store backing the [Session] facade.
+///
+/// Holds two buckets: `_current` (readable by the next view) and `_next`
+/// (being collected by the active handler). [tick] promotes `_next` into
+/// `_current`, wiping what was there. The typical cycle is:
+///
+/// 1. Controller fails validation, calls `Session.flash(data)` + `flashErrors(errors)`.
+/// 2. Navigation back to the form triggers a [tick], promoting the bucket.
+/// 3. Form reads `old('email')` and `error('email')` to repopulate.
+/// 4. Next navigation [tick]s again, clearing the flash.
+class SessionStore {
+  SessionStore();
+
+  Map<String, dynamic> _current = const <String, dynamic>{};
+  Map<String, List<String>> _currentErrors = const <String, List<String>>{};
+
+  Map<String, dynamic> _next = <String, dynamic>{};
+  Map<String, List<String>> _nextErrors = <String, List<String>>{};
+
+  /// Flash input values. Read on the next view frame via [old].
+  void flash(Map<String, dynamic> input) {
+    _next.addAll(input);
+  }
+
+  /// Flash validation errors. Read on the next view frame via [error].
+  void flashErrors(Map<String, List<String>> errors) {
+    _nextErrors.addAll(errors);
+  }
+
+  /// Read a flashed input value.
+  String? old(String field, [String? fallback]) {
+    final value = _current[field];
+    if (value == null) return fallback;
+    return value.toString();
+  }
+
+  /// Read the raw flashed value (non-stringified).
+  dynamic oldRaw(String field) => _current[field];
+
+  /// Read the first flashed error message for a field.
+  String? error(String field) {
+    final list = _currentErrors[field];
+    if (list == null || list.isEmpty) return null;
+    return list.first;
+  }
+
+  /// Read all flashed errors for a field (Laravel: `$errors->get('field')`).
+  List<String> errors(String field) =>
+      List.unmodifiable(_currentErrors[field] ?? const <String>[]);
+
+  /// Whether any flashed input or errors are currently visible.
+  bool get hasFlash => _current.isNotEmpty || _currentErrors.isNotEmpty;
+
+  /// Whether a field has a flashed error.
+  bool hasError(String field) => _currentErrors.containsKey(field);
+
+  /// Advance the flash bucket: promote `_next` to `_current`, clear `_next`.
+  /// Call on every navigation to make flashed data survive exactly one hop.
+  void tick() {
+    _current = _next;
+    _currentErrors = _nextErrors;
+    _next = <String, dynamic>{};
+    _nextErrors = <String, List<String>>{};
+  }
+
+  /// Wipe both buckets. Intended for tests.
+  void reset() {
+    _current = const <String, dynamic>{};
+    _currentErrors = const <String, List<String>>{};
+    _next = <String, dynamic>{};
+    _nextErrors = <String, List<String>>{};
+  }
+}

--- a/lib/src/ui/magic_form_data.dart
+++ b/lib/src/ui/magic_form_data.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 
 import '../concerns/validates_requests.dart';
+import '../facades/session.dart';
 import '../http/magic_controller.dart';
 
 /// Centralized form data management for Magic framework.
@@ -116,13 +117,19 @@ class MagicFormData {
 
   /// Validate the form.
   ///
-  /// Returns `true` if form is valid.
+  /// Returns `true` if form is valid. On failure, the current input is
+  /// flashed via [Session] so downstream views can repopulate via
+  /// `old('field')` after a back navigation.
   bool validate() {
     // Clear server errors before validation
     if (controller != null && controller is ValidatesRequests) {
       (controller as ValidatesRequests).clearErrors();
     }
-    return formKey.currentState?.validate() ?? false;
+    final ok = formKey.currentState?.validate() ?? false;
+    if (!ok) {
+      Session.flash(data);
+    }
+    return ok;
   }
 
   /// Validate the form and return the data if valid.

--- a/test/session/session_test.dart
+++ b/test/session/session_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+
+void main() {
+  setUp(() {
+    MagicApp.reset();
+    Magic.flush();
+    Session.reset();
+  });
+
+  group('SessionStore flash lifecycle', () {
+    test('flash values are not readable until tick', () {
+      Session.flash({'email': 'john@test.com'});
+      expect(Session.old('email'), isNull);
+      Session.tick();
+      expect(Session.old('email'), equals('john@test.com'));
+    });
+
+    test('flash survives exactly one tick', () {
+      Session.flash({'email': 'john@test.com'});
+      Session.tick();
+      expect(Session.old('email'), equals('john@test.com'));
+      Session.tick();
+      expect(Session.old('email'), isNull);
+    });
+
+    test('old() returns fallback when no flash', () {
+      expect(Session.old('missing', 'fallback'), equals('fallback'));
+    });
+
+    test('oldRaw preserves original type', () {
+      Session.flash({'accept': true, 'age': 42});
+      Session.tick();
+      expect(Session.oldRaw('accept'), isTrue);
+      expect(Session.oldRaw('age'), equals(42));
+      expect(Session.old('accept'), equals('true'));
+    });
+
+    test('flashErrors surfaces on next frame', () {
+      Session.flashErrors({
+        'email': ['Invalid email.'],
+      });
+      expect(Session.error('email'), isNull);
+      Session.tick();
+      expect(Session.error('email'), equals('Invalid email.'));
+      expect(Session.hasError('email'), isTrue);
+      expect(Session.errors('email'), equals(['Invalid email.']));
+    });
+
+    test('errors() returns empty list for unknown field', () {
+      expect(Session.errors('missing'), isEmpty);
+    });
+
+    test('hasFlash reflects current bucket', () {
+      expect(Session.hasFlash, isFalse);
+      Session.flash({'email': 'x'});
+      expect(Session.hasFlash, isFalse);
+      Session.tick();
+      expect(Session.hasFlash, isTrue);
+      Session.tick();
+      expect(Session.hasFlash, isFalse);
+    });
+
+    test('reset wipes both buckets', () {
+      Session.flash({'email': 'x'});
+      Session.tick();
+      Session.flash({'name': 'y'});
+      Session.reset();
+      expect(Session.hasFlash, isFalse);
+      expect(Session.old('email'), isNull);
+      Session.tick();
+      expect(Session.old('name'), isNull);
+    });
+
+    test('top-level old() helper mirrors facade', () {
+      Session.flash({'email': 'hi@test.com'});
+      Session.tick();
+      expect(old('email'), equals('hi@test.com'));
+      expect(old('missing', 'fb'), equals('fb'));
+    });
+
+    test('top-level error() helper mirrors facade', () {
+      Session.flashErrors({
+        'email': ['Bad.'],
+      });
+      Session.tick();
+      expect(error('email'), equals('Bad.'));
+    });
+
+    test('setStore swaps backing store', () {
+      final custom = SessionStore();
+      Session.setStore(custom);
+      custom.flash({'k': 'v'});
+      custom.tick();
+      expect(Session.old('k'), equals('v'));
+    });
+  });
+
+  group('MagicFormData auto-flash integration', () {
+    testWidgets('validate() flashes form data on failure', (tester) async {
+      final form = MagicFormData({'email': 'not-an-email'});
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MagicForm(
+              formData: form,
+              child: TextFormField(
+                controller: form['email'],
+                validator: (v) =>
+                    v != null && v.contains('@') ? null : 'Invalid email.',
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(form.validate(), isFalse);
+      Session.tick();
+      expect(Session.old('email'), equals('not-an-email'));
+    });
+
+    testWidgets('validate() does not flash on success', (tester) async {
+      final form = MagicFormData({'email': 'ok@test.com'});
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MagicForm(
+              formData: form,
+              child: TextFormField(
+                controller: form['email'],
+                validator: (v) =>
+                    v != null && v.contains('@') ? null : 'Invalid email.',
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(form.validate(), isTrue);
+      Session.tick();
+      expect(Session.hasFlash, isFalse);
+    });
+  });
+}

--- a/test/session/session_test.dart
+++ b/test/session/session_test.dart
@@ -29,6 +29,20 @@ void main() {
       expect(Session.old('missing', 'fallback'), equals('fallback'));
     });
 
+    test('old() distinguishes unset from explicit null', () {
+      Session.flash({'name': null});
+      Session.tick();
+      expect(Session.old('name', 'fallback'), isNull);
+      expect(Session.old('missing', 'fallback'), equals('fallback'));
+    });
+
+    test('hasError is false when flashed error list is empty', () {
+      Session.flashErrors({'email': const <String>[]});
+      Session.tick();
+      expect(Session.hasError('email'), isFalse);
+      expect(Session.error('email'), isNull);
+    });
+
     test('oldRaw preserves original type', () {
       Session.flash({'accept': true, 'age': 42});
       Session.tick();


### PR DESCRIPTION
## Summary
- Introduce `Session` facade with Laravel-style flash data: `flash`, `flashErrors`, `old`, `oldRaw`, `error`, `errors`, `hasError`, `hasFlash`, `tick`, `reset`, `setStore`. Two-bucket store promotes flashed values exactly one tick so they survive one navigation hop.
- Top-level helpers `old(field, [fallback])` and `error(field)` mirror Laravel's Blade API.
- `MagicFormData.validate()` auto-flashes form data on failure — forms repopulate via `old('field')` after back navigation with zero wiring.
- Router wiring is explicit: attach `Session.tick` to `routerDelegate` in a `ServiceProvider.boot()`.

## Test plan
- [x] `flutter test test/session/session_test.dart` — 13 tests passing (lifecycle, fallback, oldRaw typing, errors, top-level helpers, setStore, MagicFormData auto-flash on fail/success)
- [x] `flutter test` — all 939 tests green
- [x] `dart analyze` — no issues
- [x] `dart format --set-exit-if-changed` — clean

Closes #70