### PR TITLE
chore(skill): sync magic-framework with [Unreleased] features

### DIFF
--- a/skills/magic-framework/SKILL.md
+++ b/skills/magic-framework/SKILL.md
@@ -327,21 +327,34 @@ Unique('/users', field: 'email').via((endpoint, field, value) async => !_taken.c
 
 ### Session Flash / old() / error()
 
-Laravel-style one-hop flash bucket. `MagicFormData.validate()` auto-flashes on failure; views read via `old()` / `error()` top-level helpers (or the `Session` facade).
+Laravel-style one-hop flash bucket. `MagicFormData.validate()` auto-flashes `form.data` on failure (input only — per-field errors are NOT auto-flashed); views read prior input via `old()`, and `error()` / `Session.hasError()` work only when errors were flashed separately (manually or from a server response).
 
 ```dart
-// On validation failure (automatic): form.validate() flashes form.data + errors.
-// Next navigation reads flashed values:
+// On validation failure (automatic): form.validate() flashes form.data.
+// Next navigation reads flashed input:
 TextField(controller: TextEditingController(text: old('email')));
+
+// error() only resolves when errors were flashed explicitly:
+Session.flashErrors({'email': ['Already taken']});
 Text(error('email') ?? '');
-if (Session.hasError('email')) ... ;
 
 // Manual flash from controller:
 Session.flash({'email': 'foo@bar.com'});
 Session.flashErrors({'email': ['Already taken']});
-MagicRoute.back();  // next frame sees flashed data
+MagicRoute.back();  // next frame sees flashed data + errors
+```
 
-Session.tick();  // promote _next → _current; called automatically on navigation
+`Session.tick()` promotes `_next` → `_current`. The framework does NOT tick automatically — wire it once at bootstrap:
+
+```dart
+var lastLocation = MagicRouter.instance.currentLocation;
+MagicRouter.instance.router.routerDelegate.addListener(() {
+  final current = MagicRouter.instance.currentLocation;
+  if (current != lastLocation) {
+    Session.tick();
+    lastLocation = current;
+  }
+});
 ```
 
 `Session.old()` returns `null` if key was flashed with `null`; returns the `fallback` only when the key was never flashed.
@@ -422,7 +435,7 @@ class ProjectController extends MagicController with MagicStateMixin<List<Projec
 | Four separate `Route.page()` for CRUD | `MagicRoute.resource(name, ctrl)` | Auto-wires canonical routes + titles |
 | `sync` rule calling API in `passes()` | Implement `AsyncRule.passesAsync()` | Sync rules must not block, async runs after sync passes |
 | `Session.old(field) ?? fallback` | `Session.old(field, fallback)` | Explicit null flash returns null; fallback only on absent key |
-| Manual `Session.flash(form.data)` on validation fail | Just call `form.validate()` | Auto-flashes form data + errors on failure |
+| Manual `Session.flash(form.data)` on validation fail | `form.validate()` auto-flashes `form.data`; call `Session.flashErrors(...)` yourself if you need `error('field')` after nav | Framework only auto-flashes inputs, not errors |
 
 ## 7. Pre-Completion Checklist
 
@@ -499,7 +512,7 @@ Official plugins extending Magic Framework. Each has its own package, service pr
 | File | Content | Load When |
 |------|---------|-----------|
 | `references/bootstrap-lifecycle.md` | Magic.init 7-step sequence, IoC API, ServiceProvider register/boot, Env/Config, Kernel, MagicApplication | Setting up app bootstrap, creating providers, or configuring environment |
-| `references/facades-api.md` | All 17 facades with method signatures and return types | Looking up any facade method signature or return type |
+| `references/facades-api.md` | All 18 facades with method signatures and return types | Looking up any facade method signature or return type |
 | `references/eloquent-orm.md` | Model definition, attributes, built-in + class-based casts (`CastsAttributes`, `EnumCast`, `ListCast`), `fill(strict:)` / `MassAssignmentException`, relations, `InteractsWithPersistence`, QueryBuilder, migrations, Blueprint | Working with models, casts, mass assignment, database queries, or migrations |
 | `references/controllers-views.md` | MagicController, MagicStateMixin, RxStatus, MagicView, MagicStatefulView, MagicStatefulViewState, MagicResponsiveView, MagicBuilder, MagicCan/MagicCannot | Building controllers or views, reactive state, authorization widgets |
 | `references/forms-validation.md` | MagicFormData (auto-flash on validate fail), MagicForm, rules(), FormValidator, ValidatesRequests, built-in rules (Required, Email, Min, Max, Confirmed, Same, Accepted), AsyncRule + Unique, FormRequest (authorize/prepared/rules/validate), ValidationException, AuthorizationException, process(), processingListenable | Building forms, sync or async validation, FormRequest objects, handling server-side errors |

--- a/skills/magic-framework/SKILL.md
+++ b/skills/magic-framework/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: magic-framework
-description: "Magic Framework: Flutter IoC + 17 Facades (Auth, Http, Cache, DB, Echo, Log, Event, Gate, MagicRoute...), Eloquent ORM, Service Providers, GoRouter, MagicController/View, forms, testing, 4 plugins."
+description: "Magic Framework: Flutter IoC + 18 Facades (Auth, Http, Cache, DB, Echo, Log, Event, Gate, Session, MagicRoute...), Eloquent ORM, FormRequest, Gate abilities, resource routing, async validation, Service Providers, testing, 4 plugins."
 version: 1.0.0-alpha.13
-when_to_use: "TRIGGER when: code imports `package:magic/magic.dart` or `package:magic/testing.dart`, or user mentions Magic.init, MagicApp, MagicController, MagicView, MagicStatefulView, MagicStatefulViewState, MagicResponsiveView, MagicFormData, MagicForm, MagicBuilder, MagicRoute, MagicResponse, Model with HasTimestamps, InteractsWithPersistence, ServiceProvider, MagicMiddleware, MagicStateMixin, ValidatesRequests, RxStatus, Auth/Http/Config/Cache/DB/Gate/Log/Event/Lang/Schema/Vault/Storage/Pick/Crypt/Launch/Echo facade, MagicApplication, MagicTitle, TitleManager, MagicTest, fetchList, fetchOne, Http.fake, Auth.fake, Echo.fake, Magic.findOrPut, Magic.make, Magic.put, Magic.find, Magic.singleton, Magic.snackbar, Magic.toast, Magic.dialog, Magic.confirm, Carbon, trans(), env(), rules(), handleApiError, MagicStarter, magic_deeplink, magic_notifications, magic_social_auth, dart run magic:magic, make:model, make:controller, make:view. DO NOT TRIGGER when: code only uses Wind UI without Magic framework, or plain Flutter without package:magic import."
+when_to_use: "TRIGGER when: code imports `package:magic/magic.dart` or `package:magic/testing.dart`, or user mentions Magic.init, MagicApp, MagicController, MagicView, MagicStatefulView, MagicStatefulViewState, MagicResponsiveView, MagicFormData, MagicForm, MagicBuilder, MagicRoute, MagicResponse, Model with HasTimestamps, InteractsWithPersistence, CastsAttributes, EnumCast, ListCast, MassAssignmentException, fill(strict:), FormRequest, AuthorizationException, ValidationException, AsyncRule, Unique rule, ResourceController, MagicRoute.resource, Gate.allowsAny, Gate.allowsAll, controller.authorize, Session facade, Session.flash, Session.old, old(), error() helper, ServiceProvider, MagicMiddleware, MagicStateMixin, ValidatesRequests, RxStatus, Auth/Http/Config/Cache/DB/Gate/Log/Event/Lang/Schema/Vault/Storage/Pick/Crypt/Launch/Echo/Session facade, MagicApplication, MagicTitle, TitleManager, MagicTest, fetchList, fetchOne, Http.fake, Auth.fake, Echo.fake, Magic.findOrPut, Magic.make, Magic.put, Magic.find, Magic.singleton, Magic.snackbar, Magic.toast, Magic.dialog, Magic.confirm, Carbon, trans(), env(), rules(), handleApiError, MagicStarter, magic_deeplink, magic_notifications, magic_social_auth, dart run magic:magic, make:model, make:controller, make:view, make:request. DO NOT TRIGGER when: code only uses Wind UI without Magic framework, or plain Flutter without package:magic import."
 ---
 
-<!-- Magic v1.0.0-alpha.13 | magic_starter v0.0.1-alpha.14 | Skill updated: 2026-04-16 -->
+<!-- Magic v1.0.0-alpha.13 + [Unreleased] | magic_starter v0.0.1-alpha.14 | Skill updated: 2026-04-18 -->
 
 # Magic Framework
 
@@ -14,7 +14,7 @@ Laravel-inspired Flutter framework. IoC Container + Facades + Eloquent ORM + GoR
 ## 1. Core Laws
 
 1. **await Magic.init()**: Must be awaited in `main()` before ANY facade call. Never `.then()`.
-2. **Facade-first**: Use `Auth`, `Http`, `Config`, `Cache`, `DB`, `Log`, `Event`, `Lang`, `MagicRoute`, `Gate`, `Schema`, `Vault`, `Storage`, `Pick`, `Crypt`, `Launch` -- never resolve manually unless extending.
+2. **Facade-first**: Use `Auth`, `Http`, `Config`, `Cache`, `DB`, `Log`, `Event`, `Echo`, `Lang`, `MagicRoute`, `Gate`, `Session`, `Schema`, `Vault`, `Storage`, `Pick`, `Crypt`, `Launch` -- never resolve manually unless extending.
 3. **Singleton controllers**: `static X get instance => Magic.findOrPut(X.new);` -- the canonical pattern.
 4. **IoC over new**: Bind services in providers, resolve via `Magic.make<T>('key')`. Never scatter `new Service()` across code.
 5. **Service Provider discipline**: `register()` = sync bindings only, routes go here. `boot()` = async, may resolve other services, set `Auth.manager.setUserFactory()` here.
@@ -68,7 +68,7 @@ Use `configFactories` (not `configs`) when any value depends on `Env.get()`. The
 | `Magic.flush()` | Clear all controllers (testing) |
 | `MagicApp.reset()` | Full container reset (testing) |
 
-### Facade Summary (17 Facades)
+### Facade Summary (18 Facades)
 
 | Facade | Purpose | Key Methods |
 |--------|---------|-------------|
@@ -81,8 +81,9 @@ Use `configFactories` (not `configs`) when any value depends on `Env.get()`. The
 | `Log` | Logging | `info()`, `error()`, `warning()`, `debug()` |
 | `Event` | Events | `dispatch(event)` |
 | `Echo` | Broadcasting | `channel()`, `private()`, `join()`, `listen()`, `leave()`, `connect()`, `disconnect()`, `socketId`, `connectionState`, `onReconnect`, `fake()` |
-| `MagicRoute` | Routing | `page()`, `group()`, `layout()`, `to()`, `back({fallback?})`, `replace()`, `push()`, `toNamed()`, `setTitle()`, `currentTitle` |
-| `Gate` | Authorization | `allows()`, `denies()`, `define()`, `policy()` |
+| `MagicRoute` | Routing | `page()`, `group()`, `layout()`, `resource(name, ctrl, {only, except})`, `to()`, `back({fallback?})`, `replace()`, `push()`, `toNamed()`, `setTitle()`, `currentTitle` |
+| `Gate` | Authorization | `allows()`, `denies()`, `allowsAny(list)`, `allowsAll(list)`, `define()`, `before()`, `policy()` |
+| `Session` | Flash data | `flash(data)`, `flashErrors(errors)`, `old(field, [fallback])`, `error(field)`, `errors(field)`, `hasError(field)`, `hasFlash`, `tick()` |
 | `Lang` | Localization | `get()`, `locale()` |
 | `Vault` | Secure storage | `get()`, `put()`, `delete()`, `flush()` |
 | `Storage` | File storage | `disk()`, `put()`, `get()`, `delete()`, `exists()` |
@@ -145,7 +146,12 @@ class User extends Model with HasTimestamps, InteractsWithPersistence {
     @override String get table => 'users';
     @override String get resource => 'users';
     @override List<String> get fillable => ['name', 'email'];
-    @override Map<String, String> get casts => {'created_at': 'datetime', 'settings': 'json'};
+    @override Map<String, dynamic> get casts => {
+        'created_at': 'datetime',
+        'settings': 'json',
+        'status': EnumCast(UserStatus.values),          // class-based cast
+        'tags': ListCast(EnumCast(UserTag.values)),      // element-wise list cast
+    };
     @override Map<String, Model Function()> get relations => {'company': Company.new};
 
     int? get id => get<int>('id');
@@ -162,7 +168,7 @@ class User extends Model with HasTimestamps, InteractsWithPersistence {
 }
 ```
 
-Casts: `datetime` (Carbon), `json` (Map), `bool`, `int`, `double`. Hybrid persistence: `save()` = API first, sync to SQLite. `find()` = local first, API fallback.
+Built-in casts: `datetime` (Carbon), `json` (Map or List), `bool`, `int`, `double`. Class-based casts implement `CastsAttributes<T>` (built-in: `EnumCast(values, {strict})`, `ListCast(inner)`). `fill(data, strict: true)` throws `MassAssignmentException` on any non-fillable key instead of silently dropping it — pair with validated request payloads. Hybrid persistence: `save()` = API first, sync to SQLite. `find()` = local first, API fallback.
 
 ### Controller Skeleton
 
@@ -181,6 +187,7 @@ class UserController extends MagicController
     }
 
     Future<void> store(Map<String, dynamic> data) async {
+        authorize('create-user');  // throws AuthorizationException if Gate denies
         setLoading(); clearErrors();
         final response = await Http.post('/users', data: data);
         if (response.successful) { Magic.toast(trans('users.created')); MagicRoute.to('/users'); return; }
@@ -253,6 +260,92 @@ form.process(() => submit())   // auto-manages processingListenable
 form.dispose()                 // always in onClose()
 ```
 
+`form.validate()` auto-flashes the current `form.data` to `Session` on failure so downstream views can repopulate via `old('field')` without manual wiring.
+
+### FormRequest (Laravel-style request object)
+
+Collapses authorize → prepare → validate into a single class. Use for complex payloads instead of inline `MagicFormData` validation.
+
+```dart
+class StoreUserRequest extends FormRequest {
+  @override bool authorize() => Gate.allows('create-user');
+
+  @override Map<String, dynamic> prepared(Map<String, dynamic> data) => {
+    ...data,
+    'email': (data['email'] as String?)?.trim().toLowerCase(),
+  };
+
+  @override Map<String, List<Rule>> rules() => {
+    'name': [Required()],
+    'email': [Required(), Email(), Unique('/users', field: 'email')],
+    'password': [Required(), Min(8), Confirmed()],
+  };
+}
+
+// Usage inside a controller:
+final validated = StoreUserRequest().validate(form.data);
+// throws AuthorizationException (authorize=false) or ValidationException (rules fail)
+final user = User()..fill(validated, strict: true);
+await user.save();
+```
+
+### Resource Routing
+
+`MagicRoute.resource(name, controller, {only, except})` auto-wires up to four canonical GET routes to a controller that mixes in `ResourceController`. Each route gets an auto-assigned `{slug}.{method}` name and title.
+
+```dart
+class UserRoutes with ResourceController {
+  @override Set<String> get resourceMethods => {'index', 'create', 'show', 'edit'};
+  @override Widget index() => const UserListView();
+  @override Widget create() => const UserCreateView();
+  @override Widget show(String id) => UserShowView(id: id);
+  @override Widget edit(String id) => UserEditView(id: id);
+}
+
+// In RouteServiceProvider.register():
+MagicRoute.resource('users', UserRoutes());                 // all four
+MagicRoute.resource('posts', PostRoutes(), only: ['index', 'show']);
+MagicRoute.resource('teams', TeamRoutes(), except: ['edit']);
+```
+
+Routes: `GET /{name}` → index, `/{name}/create` → create, `/{name}/:id` → show, `/{name}/:id/edit` → edit. Unknown method names in `only`/`except` throw `ArgumentError`.
+
+### Async Validation (Unique)
+
+`AsyncRule` contract + `Unique(endpoint, field:)` rule. Debounces rapid calls (default 400ms), passes on network errors so submit never blocks, and stale in-flight requests are discarded.
+
+```dart
+Validator.make(data, {
+  'email': [Required(), Email(), Unique('/users', field: 'email')],
+}).validateAsync();  // Future<Map<String, dynamic>> — throws ValidationException
+
+// Custom resolver (test or non-HTTP backend):
+Unique('/users', field: 'email').via((endpoint, field, value) async => !_taken.contains(value));
+```
+
+`Validator.validateAsync()` runs sync rules first, then async for fields that passed. Swap the resolver via `.via()` for testing or alternate backends.
+
+### Session Flash / old() / error()
+
+Laravel-style one-hop flash bucket. `MagicFormData.validate()` auto-flashes on failure; views read via `old()` / `error()` top-level helpers (or the `Session` facade).
+
+```dart
+// On validation failure (automatic): form.validate() flashes form.data + errors.
+// Next navigation reads flashed values:
+TextField(controller: TextEditingController(text: old('email')));
+Text(error('email') ?? '');
+if (Session.hasError('email')) ... ;
+
+// Manual flash from controller:
+Session.flash({'email': 'foo@bar.com'});
+Session.flashErrors({'email': ['Already taken']});
+MagicRoute.back();  // next frame sees flashed data
+
+Session.tick();  // promote _next → _current; called automatically on navigation
+```
+
+`Session.old()` returns `null` if key was flashed with `null`; returns the `fallback` only when the key was never flashed.
+
 ## 5. Testing
 
 ### Test Bootstrap
@@ -324,6 +417,12 @@ class ProjectController extends MagicController with MagicStateMixin<List<Projec
 | Missing `.title()` on routes | `MagicRoute.page('/x', () => X()).title('Page')` | Browser tab shows generic title |
 | `configs: {'routing': {'url_strategy': 'path'}}` | Use `configFactories` | Env not loaded when `configs` evaluates |
 | `FilePicker.platform.pickFiles()` | `FilePicker.pickFiles()` | v11 migrated to static API |
+| `user.fill(unvalidated)` | `user.fill(validated, strict: true)` | Use strict after FormRequest/Validator — catches schema drift |
+| Hand-rolled `if (!Gate.allows(...)) throw ...` | `authorize('ability')` inside controller | Delegates to Gate + throws `AuthorizationException` |
+| Four separate `Route.page()` for CRUD | `MagicRoute.resource(name, ctrl)` | Auto-wires canonical routes + titles |
+| `sync` rule calling API in `passes()` | Implement `AsyncRule.passesAsync()` | Sync rules must not block, async runs after sync passes |
+| `Session.old(field) ?? fallback` | `Session.old(field, fallback)` | Explicit null flash returns null; fallback only on absent key |
+| Manual `Session.flash(form.data)` on validation fail | Just call `form.validate()` | Auto-flashes form data + errors on failure |
 
 ## 7. Pre-Completion Checklist
 
@@ -401,13 +500,13 @@ Official plugins extending Magic Framework. Each has its own package, service pr
 |------|---------|-----------|
 | `references/bootstrap-lifecycle.md` | Magic.init 7-step sequence, IoC API, ServiceProvider register/boot, Env/Config, Kernel, MagicApplication | Setting up app bootstrap, creating providers, or configuring environment |
 | `references/facades-api.md` | All 17 facades with method signatures and return types | Looking up any facade method signature or return type |
-| `references/eloquent-orm.md` | Model definition, attributes, casts, relations, `InteractsWithPersistence`, QueryBuilder, migrations, Blueprint | Working with models, database queries, or migrations |
+| `references/eloquent-orm.md` | Model definition, attributes, built-in + class-based casts (`CastsAttributes`, `EnumCast`, `ListCast`), `fill(strict:)` / `MassAssignmentException`, relations, `InteractsWithPersistence`, QueryBuilder, migrations, Blueprint | Working with models, casts, mass assignment, database queries, or migrations |
 | `references/controllers-views.md` | MagicController, MagicStateMixin, RxStatus, MagicView, MagicStatefulView, MagicStatefulViewState, MagicResponsiveView, MagicBuilder, MagicCan/MagicCannot | Building controllers or views, reactive state, authorization widgets |
-| `references/forms-validation.md` | MagicFormData, MagicForm, rules(), FormValidator, ValidatesRequests, built-in rules (Required, Email, Min, Max, Confirmed, Same, Accepted), process(), processingListenable | Building forms, adding validation, handling server-side errors |
-| `references/routing-navigation.md` | MagicRoute.page(), group(), layout(), navigation (to/back/replace/push/toNamed), middleware, transitions, MagicRouterOutlet, path/query parameters, navigator observers, URL strategy, page titles (TitleManager, MagicTitle, setTitle/currentTitle) | Defining routes, navigation, middleware, observers, URL strategy, or page title management |
+| `references/forms-validation.md` | MagicFormData (auto-flash on validate fail), MagicForm, rules(), FormValidator, ValidatesRequests, built-in rules (Required, Email, Min, Max, Confirmed, Same, Accepted), AsyncRule + Unique, FormRequest (authorize/prepared/rules/validate), ValidationException, AuthorizationException, process(), processingListenable | Building forms, sync or async validation, FormRequest objects, handling server-side errors |
+| `references/routing-navigation.md` | MagicRoute.page(), group(), layout(), resource() + ResourceController, navigation (to/back/replace/push/toNamed), middleware, transitions, MagicRouterOutlet, path/query parameters, navigator observers, URL strategy, page titles (TitleManager, MagicTitle, setTitle/currentTitle) | Defining routes (including resource shorthand), navigation, middleware, observers, URL strategy, or page title management |
 | `references/http-network.md` | Http facade (get/post/put/delete/upload + RESTful resource methods), MagicResponse API, interceptors, network config | Making HTTP requests, handling responses, or configuring network layer |
-| `references/auth-system.md` | Auth facade, AuthManager, guards (Bearer, BasicAuth, ApiKey), token refresh, setUserFactory, restore, policies, Gate, MagicCan | Implementing authentication, authorization, or token management |
-| `references/secondary-systems.md` | Cache, Events (EventDispatcher, register listeners), Logging, Localization (trans()), Storage, Encryption, Vault, Carbon date helper, Launch, Policies, Broadcasting (Echo facade, BroadcastManager, channels, interceptors) | Using caching, events, logging, i18n, file storage, encryption, URL launching, or real-time broadcasting |
+| `references/auth-system.md` | Auth facade, AuthManager, guards (Bearer, BasicAuth, ApiKey), token refresh, setUserFactory, restore, policies, Gate (allows/denies/allowsAny/allowsAll/define/before), MagicController.authorize(), MagicCan | Implementing authentication, authorization, gate abilities, controller authorize(), or token management |
+| `references/secondary-systems.md` | Cache, Events (EventDispatcher, register listeners), Logging, Localization (trans()), Session (flash, old, error, hasError, tick), Storage, Encryption, Vault, Carbon date helper, Launch, Policies, Broadcasting (Echo facade, BroadcastManager, channels, interceptors) | Using caching, events, logging, i18n, flash sessions, file storage, encryption, URL launching, or real-time broadcasting |
 | `references/testing-patterns.md` | MagicTest.init/boot, facade faking (Http.fake, Auth.fake, Cache.fake, Vault.fake, Log.fake), fetchList/fetchOne, controller/model/middleware testing | Writing tests for any Magic framework code |
 | `references/cli-commands.md` | Full CLI reference: install, all make:* generators with flags, key:generate | Scaffolding code, initializing projects, or generating files with the CLI |
 | `references/plugin-deeplink.md` | DeeplinkManager, handlers, drivers, config, RouteDeeplinkHandler, OneSignalDeeplinkHandler | Working with deep links, universal links, or app links |

--- a/skills/magic-framework/references/auth-system.md
+++ b/skills/magic-framework/references/auth-system.md
@@ -358,6 +358,16 @@ if (Gate.check('view-dashboard')) {
   showDashboard();
 }
 
+// Pass if ANY of the abilities passes (short-circuits on first pass)
+if (Gate.allowsAny(['edit-post', 'delete-post'], post)) {
+  showActionMenu();
+}
+
+// Pass only if ALL abilities pass (short-circuits on first failure)
+if (Gate.allowsAll(['view-admin', 'edit-users'])) {
+  showUserAdminPanel();
+}
+
 // Check if ability exists
 if (Gate.has('update-post')) {
   // ...
@@ -365,6 +375,32 @@ if (Gate.has('update-post')) {
 
 // Get all defined abilities
 final abilities = Gate.abilities;
+```
+
+### MagicController.authorize()
+
+Laravel-style controller helper that delegates to `Gate.allows()` and throws `AuthorizationException` on denial. Use inside controller actions instead of hand-rolled gate checks.
+
+```dart
+// on MagicController:
+void authorize(String ability, [Object? arguments]);
+
+class PostController extends MagicController {
+  Future<void> destroy(Post post) async {
+    authorize('delete-post', post);  // throws AuthorizationException('delete-post') if Gate denies
+    await post.delete();
+  }
+}
+```
+
+Catch globally (in middleware or a top-level handler) or locally:
+
+```dart
+try {
+  controller.destroy(post);
+} on AuthorizationException catch (e) {
+  Magic.error(trans('errors.forbidden'), e.message);
+}
 ```
 
 ### Super Admin Bypass

--- a/skills/magic-framework/references/auth-system.md
+++ b/skills/magic-framework/references/auth-system.md
@@ -387,7 +387,7 @@ void authorize(String ability, [Object? arguments]);
 
 class PostController extends MagicController {
   Future<void> destroy(Post post) async {
-    authorize('delete-post', post);  // throws AuthorizationException('delete-post') if Gate denies
+    authorize('delete-post', post);  // throws AuthorizationException('This action is unauthorized: delete-post') if Gate denies
     await post.delete();
   }
 }
@@ -397,7 +397,7 @@ Catch globally (in middleware or a top-level handler) or locally:
 
 ```dart
 try {
-  controller.destroy(post);
+  await controller.destroy(post);
 } on AuthorizationException catch (e) {
   Magic.error(trans('errors.forbidden'), e.message);
 }

--- a/skills/magic-framework/references/eloquent-orm.md
+++ b/skills/magic-framework/references/eloquent-orm.md
@@ -68,7 +68,7 @@ class Monitor extends Model with HasTimestamps, InteractsWithPersistence {
 | `useRemote` | `bool` | `true` | Enable API calls |
 | `fillable` | `List<String>` | `[]` | Mass-assignable fields |
 | `guarded` | `List<String>` | `['*']` | Guarded fields (default blocks all) |
-| `casts` | `Map<String, String>` | `{}` | Type casting map |
+| `casts` | `Map<String, dynamic>` | `{}` | Type casting map (string tokens or `CastsAttributes<T>` instances) |
 | `hidden` | `List<String>` | `[]` | Hidden from serialization |
 | `visible` | `List<String>` | `[]` | Whitelist for serialization |
 | `relations` | `Map<String, Model Function()>` | `{}` | Relation factories |
@@ -80,7 +80,7 @@ class Monitor extends Model with HasTimestamps, InteractsWithPersistence {
 | `get<T>` | `T? get<T>(String key, {T? defaultValue})` | Typed read with cast support (preferred) |
 | `set` | `void set(String key, dynamic value)` | Write attribute |
 | `has` | `bool has(String key)` | Check non-null existence |
-| `fill` | `void fill(Map<String, dynamic> attributes)` | Mass assign (respects fillable/guarded) |
+| `fill` | `void fill(Map<String, dynamic> attributes, {bool strict = false})` | Mass assign (respects fillable/guarded); when `strict: true`, throws `MassAssignmentException` on non-fillable keys instead of silently dropping them |
 | `getAttribute` | `dynamic getAttribute(String key)` | Raw read with casting (used internally) |
 | `setAttribute` | `void setAttribute(String key, dynamic value)` | Raw write with type conversion |
 | `setRawAttributes` | `void setRawAttributes(Map<String, dynamic> attributes, {bool sync = false})` | Bulk hydrate, bypass fillable |
@@ -97,13 +97,56 @@ class Monitor extends Model with HasTimestamps, InteractsWithPersistence {
 
 ## Casting
 
+### Built-in string-token casts
+
 | Cast | Dart Type | Conversion |
 | :--- | :--- | :--- |
 | `datetime` | `Carbon` | ISO 8601 string ↔ Carbon; Carbon stored as ISO 8601 string |
-| `json` | `Map<String, dynamic>` | JSON string ↔ Map; Map stored as JSON string |
+| `json` | `Map<String, dynamic>` or `List` | JSON string ↔ Map/List; Map/List stored as JSON string |
 | `bool` | `bool` | int 0/1 or string `"true"`/`"false"` |
 | `int` | `int` | Safe parse via `int.tryParse` |
 | `double` | `double` | Safe parse via `double.tryParse` |
+
+### Class-based casts (`CastsAttributes<T>`)
+
+Implement `CastsAttributes<T>` for reusable, typed, custom casts. Two built-in implementations ship in `package:magic/magic.dart`:
+
+```dart
+abstract class CastsAttributes<T> {
+  const CastsAttributes();
+  T? get(Model model, String key, Object? raw);       // storage -> domain
+  Object? set(Model model, String key, Object? value); // domain -> storage
+}
+```
+
+```dart
+// EnumCast — map a name-based string column to an enum.
+enum MonitorStatus { up, down, paused }
+
+@override Map<String, dynamic> get casts => {
+  'status': EnumCast(MonitorStatus.values),                   // unknown values return null
+  'strict_status': EnumCast(MonitorStatus.values, strict: true), // throws ArgumentError on unknown value
+};
+
+// ListCast — apply an inner cast element-by-element. Stored as JSON string.
+@override Map<String, dynamic> get casts => {
+  'tags': ListCast(EnumCast(MonitorTag.values)),
+};
+```
+
+`ListCast.get()` accepts either a `List`, a JSON string, or a single value (coerced into `[value]`). `ListCast.set()` emits JSON when given a `List`; otherwise passes raw storage forms through unchanged.
+
+Mix string-token and class-based entries in the same `casts` map — resolution happens per key.
+
+## Mass Assignment & MassAssignmentException
+
+```dart
+final user = User();
+user.fill({'name': 'Ada', 'role': 'admin'});                // 'role' silently dropped (not fillable)
+user.fill({'name': 'Ada', 'role': 'admin'}, strict: true);  // throws MassAssignmentException('role', User)
+```
+
+`MassAssignmentException` is an `Exception` with `.attribute` (the offending key) and optional `.modelType`. Pair `strict: true` with a validated payload (e.g., from `FormRequest.validate()` or `Validator.validate()`) so schema drift fails loudly at the boundary instead of corrupting state.
 
 ## Relations
 

--- a/skills/magic-framework/references/facades-api.md
+++ b/skills/magic-framework/references/facades-api.md
@@ -253,6 +253,8 @@ Uses a `GateManager` singleton. `AbilityCallback = Function`, `BeforeCallback = 
 | `Gate.allows(String ability, [dynamic arguments])` | `bool` | True if current user has the ability. |
 | `Gate.denies(String ability, [dynamic arguments])` | `bool` | Inverse of `allows()`. |
 | `Gate.check(String ability, [dynamic arguments])` | `bool` | Alias for `allows()`. |
+| `Gate.allowsAny(List<String> abilities, [dynamic arguments])` | `bool` | True if **any** listed ability passes. Short-circuits on first pass. |
+| `Gate.allowsAll(List<String> abilities, [dynamic arguments])` | `bool` | True only if **all** listed abilities pass. Short-circuits on first failure. |
 | `Gate.has(String ability)` | `bool` | Check if an ability has been defined. |
 | `Gate.abilities` | `List<String>` | **Getter.** All defined ability names. |
 | `Gate.flush()` | `void` | Remove all abilities (primarily for testing). |
@@ -391,6 +393,50 @@ if (await Launch.canLaunch('tel:+1234567890')) {
 
 ---
 
+## Session
+
+Laravel-style flash store. Data written via `flash()` / `flashErrors()` lives in a **next** bucket and is promoted to **current** on the next navigation (`tick()` is called automatically by the router). Each value survives exactly one hop.
+
+| Signature | Return Type | Notes |
+|-----------|-------------|-------|
+| `Session.flash(Map<String, dynamic> input)` | `void` | Flash input values for the next request (merged). |
+| `Session.flashErrors(Map<String, List<String>> errors)` | `void` | Flash validation errors for the next request (merged). |
+| `Session.old(String field, [String? fallback])` | `String?` | Read flashed input as string. Returns `fallback` only if the key was **never** flashed; explicit null flash returns `null`. |
+| `Session.oldRaw(String field)` | `dynamic` | Read the raw, non-stringified flashed value. |
+| `Session.error(String field)` | `String?` | First flashed error for field, or `null`. |
+| `Session.errors(String field)` | `List<String>` | All flashed errors for field. |
+| `Session.hasError(String field)` | `bool` | True if the field has at least one flashed error. |
+| `Session.hasFlash` | `bool` | **Getter.** Any flash data readable this frame. |
+| `Session.tick()` | `void` | Promote `_next` → `_current`. Router calls this on every navigation; call manually in tests. |
+| `Session.reset()` | `void` | Clear both buckets (testing). |
+| `Session.store` | `SessionStore` | Underlying store (for direct inspection). |
+| `Session.setStore(SessionStore store)` | `void` | Swap the backing store (testing). |
+
+Top-level helpers (mirror Laravel's Blade API):
+
+```dart
+String? old(String field, [String? fallback]);
+String? error(String field);
+```
+
+```dart
+import 'package:magic/magic.dart';
+
+// Controller flashes on validation failure:
+Session.flash({'email': form.get('email')});
+Session.flashErrors({'email': ['The email is already taken.']});
+MagicRoute.back();
+
+// Next view repopulates:
+TextField(controller: TextEditingController(text: old('email')));
+Text(error('email') ?? '');
+if (Session.hasError('email')) showErrorIcon();
+```
+
+`MagicFormData.validate()` auto-flashes `form.data` and current validation errors on failure, so typical "submit → validate fails → navigate back → repopulate" flows need no manual `flash()` calls.
+
+---
+
 ## Log
 
 Resolves `Magic.make<LogManager>('log')`. Supports all RFC 5424 levels.
@@ -463,6 +509,7 @@ The facade class is `MagicRoute`. Resolves `MagicRouter.instance`.
 | `MagicRoute.page(String path, Function handler)` | `RouteDefinition` | Register a page route; returns definition for fluent chaining. |
 | `MagicRoute.group({String? prefix, List middleware, String? as, Widget Function(Widget)? layout, String? layoutId, required void Function() routes})` | `void` | Group routes with shared prefix/middleware. |
 | `MagicRoute.layout({String? id, required Widget Function(Widget child) builder, required List<RouteDefinition> routes})` | `void` | Persistent shell layout for nested routes. |
+| `MagicRoute.resource(String name, ResourceController controller, {List<String>? only, List<String>? except})` | `List<RouteDefinition>` | Auto-wire canonical GET routes (index/create/show/edit) to a `ResourceController` mixin. Each definition gets a `{slug}.{method}` name + title. Throws `ArgumentError` for unknown method names in `only`/`except`. |
 | `MagicRoute.to(String path, {Map<String, String>? query})` | `void` | Navigate to path — no BuildContext needed. |
 | `MagicRoute.toNamed(String name, {Map<String, String> params, Map<String, String> query})` | `void` | Navigate by named route. |
 | `MagicRoute.push(String path)` | `void` | Push path onto the navigation stack. |

--- a/skills/magic-framework/references/facades-api.md
+++ b/skills/magic-framework/references/facades-api.md
@@ -395,7 +395,7 @@ if (await Launch.canLaunch('tel:+1234567890')) {
 
 ## Session
 
-Laravel-style flash store. Data written via `flash()` / `flashErrors()` lives in a **next** bucket and is promoted to **current** on the next navigation (`tick()` is called automatically by the router). Each value survives exactly one hop.
+Laravel-style flash store. Data written via `flash()` / `flashErrors()` lives in a **next** bucket and is promoted to **current** when the app calls `Session.tick()`. The router does NOT tick automatically — wire a routerDelegate listener gated on `MagicRouter.instance.currentLocation` changes during bootstrap (see example below). Each value survives exactly one hop.
 
 | Signature | Return Type | Notes |
 |-----------|-------------|-------|
@@ -407,7 +407,7 @@ Laravel-style flash store. Data written via `flash()` / `flashErrors()` lives in
 | `Session.errors(String field)` | `List<String>` | All flashed errors for field. |
 | `Session.hasError(String field)` | `bool` | True if the field has at least one flashed error. |
 | `Session.hasFlash` | `bool` | **Getter.** Any flash data readable this frame. |
-| `Session.tick()` | `void` | Promote `_next` → `_current`. Router calls this on every navigation; call manually in tests. |
+| `Session.tick()` | `void` | Promote `_next` → `_current`. Not called automatically — wire it once at bootstrap via a routerDelegate listener gated on actual location changes; call manually in tests. |
 | `Session.reset()` | `void` | Clear both buckets (testing). |
 | `Session.store` | `SessionStore` | Underlying store (for direct inspection). |
 | `Session.setStore(SessionStore store)` | `void` | Swap the backing store (testing). |
@@ -422,6 +422,16 @@ String? error(String field);
 ```dart
 import 'package:magic/magic.dart';
 
+// Bootstrap (call once — Magic does not tick Session automatically):
+var lastLocation = MagicRouter.instance.currentLocation;
+MagicRouter.instance.router.routerDelegate.addListener(() {
+  final current = MagicRouter.instance.currentLocation;
+  if (current != lastLocation) {
+    Session.tick();
+    lastLocation = current;
+  }
+});
+
 // Controller flashes on validation failure:
 Session.flash({'email': form.get('email')});
 Session.flashErrors({'email': ['The email is already taken.']});
@@ -433,7 +443,7 @@ Text(error('email') ?? '');
 if (Session.hasError('email')) showErrorIcon();
 ```
 
-`MagicFormData.validate()` auto-flashes `form.data` and current validation errors on failure, so typical "submit → validate fails → navigate back → repopulate" flows need no manual `flash()` calls.
+`MagicFormData.validate()` auto-flashes `form.data` on failure (but not per-field errors — call `Session.flashErrors(...)` manually when you need `error('field')` to resolve after navigating back).
 
 ---
 

--- a/skills/magic-framework/references/forms-validation.md
+++ b/skills/magic-framework/references/forms-validation.md
@@ -39,7 +39,7 @@ The optional `controller` param enables two side-effects:
 | `form.get('field')` | `String` | Get trimmed text from a text controller |
 | `form.set('field', 'text')` | `void` | Set text value in a text controller |
 | `form.data` | `Map<String, dynamic>` | Export all values (text fields are auto-trimmed) |
-| `form.validate()` | `bool` | Run client-side validation (clears server errors first). **Auto-flashes `form.data` + errors to `Session` on failure** so downstream views can repopulate via `old('field')` / `error('field')` |
+| `form.validate()` | `bool` | Run client-side validation (clears server errors first). **Auto-flashes `form.data` to `Session` on failure** so downstream views can repopulate via `old('field')`. Per-field validation errors are not auto-flashed — call `Session.flashErrors(...)` manually if you need `error('field')` after navigation |
 | `form.validated()` | `Map<String, dynamic>` | Returns `data` if valid, otherwise empty `{}` |
 | `form.process<T>(action)` | `Future<T>` | Execute async action with automatic processing state management |
 | `form.isProcessing` | `bool` | Whether `process()` is currently executing |

--- a/skills/magic-framework/references/forms-validation.md
+++ b/skills/magic-framework/references/forms-validation.md
@@ -39,7 +39,7 @@ The optional `controller` param enables two side-effects:
 | `form.get('field')` | `String` | Get trimmed text from a text controller |
 | `form.set('field', 'text')` | `void` | Set text value in a text controller |
 | `form.data` | `Map<String, dynamic>` | Export all values (text fields are auto-trimmed) |
-| `form.validate()` | `bool` | Run client-side validation (clears server errors first) |
+| `form.validate()` | `bool` | Run client-side validation (clears server errors first). **Auto-flashes `form.data` + errors to `Session` on failure** so downstream views can repopulate via `old('field')` / `error('field')` |
 | `form.validated()` | `Map<String, dynamic>` | Returns `data` if valid, otherwise empty `{}` |
 | `form.process<T>(action)` | `Future<T>` | Execute async action with automatic processing state management |
 | `form.isProcessing` | `bool` | Whether `process()` is currently executing |
@@ -193,6 +193,7 @@ try {
 | `passes()` | `bool` | Inverse of `fails()` |
 | `errors()` | `Map<String, String>` | Map of field name to first error message |
 | `validate()` | `Map<String, dynamic>` | Returns only validated fields on success; throws `ValidationException` on failure |
+| `validateAsync()` | `Future<Map<String, dynamic>>` | Runs sync rules first, then `AsyncRule.passesAsync()` for fields that passed; throws `ValidationException` on failure |
 
 
 ## ValidatesRequests Mixin
@@ -433,3 +434,121 @@ class _RegisterViewState
 - `Confirmed` looks for `{field}_confirmation` in form data. `Same` requires an explicit field name and supports `valueGetter` for live values.
 - `Accepted` accepts `true`, `1`, `'1'`, `'yes'`, `'on'`, `'true'` — use it for terms checkboxes, not `Required`.
 - Always call `form.dispose()` in `onClose()` to prevent memory leaks.
+
+
+## FormRequest
+
+Laravel-style request object that collapses **authorize → prepare → validate** into a single reusable class. Import from `package:magic/magic.dart`.
+
+```dart
+abstract class FormRequest {
+  const FormRequest();
+
+  Map<String, List<Rule>> rules();                              // required
+  bool authorize() => true;                                     // override to deny
+  Map<String, dynamic> prepared(Map<String, dynamic> data) => data; // override to normalize
+
+  /// Runs authorize → prepared → validation.
+  /// Throws AuthorizationException if authorize() == false.
+  /// Throws ValidationException (with field-keyed errors) on rule failure.
+  /// Returns the validated + prepared data (keys present in rules only).
+  Map<String, dynamic> validate(Map<String, dynamic> data);
+}
+```
+
+### Example
+
+```dart
+class StoreUserRequest extends FormRequest {
+  @override bool authorize() => Gate.allows('create-user');
+
+  @override Map<String, dynamic> prepared(Map<String, dynamic> data) => {
+    ...data,
+    'email': (data['email'] as String?)?.trim().toLowerCase(),
+  };
+
+  @override Map<String, List<Rule>> rules() => {
+    'name': [Required()],
+    'email': [Required(), Email()],
+    'password': [Required(), Min(8), Confirmed()],
+  };
+}
+
+// In a controller action:
+try {
+  final validated = StoreUserRequest().validate(form.data);
+  final user = User()..fill(validated, strict: true);
+  await user.save();
+} on AuthorizationException catch (e) {
+  Magic.error(trans('errors.forbidden'), e.message);
+} on ValidationException catch (e) {
+  // e.errors -> Map<String, String> of field -> first error
+  controller.setValidationErrors(e.errors);
+}
+```
+
+Pair with `Model.fill(validated, strict: true)` to catch schema drift at the boundary — any unexpected key in `validated` becomes `MassAssignmentException` instead of silently corrupting state.
+
+### Exceptions
+
+| Exception | Fields | Thrown by |
+|-----------|--------|-----------|
+| `AuthorizationException` | `message` (default `'Unauthorized.'`) | `FormRequest.validate()` when `authorize()` returns `false`; `MagicController.authorize()` when `Gate.denies()` |
+| `ValidationException` | `errors` (`Map<String, String>`) | `FormRequest.validate()`, `Validator.validate()`, `Validator.validateAsync()` |
+
+### CLI
+
+Generate a FormRequest with: `dart run magic:magic make:request StoreUser`.
+
+
+## AsyncRule & Unique
+
+Sync rules run inside `Validator.fails()` / `passes()`. Async rules implement `AsyncRule` and run only when the caller uses `Validator.validateAsync()`.
+
+```dart
+abstract class AsyncRule extends Rule {
+  Future<bool> passesAsync(String attribute, dynamic value, Map<String, dynamic> data);
+  @override bool passes(String a, dynamic v, Map<String, dynamic> d) => true; // sync no-op
+}
+```
+
+### Unique(endpoint, field:)
+
+Built-in async rule for uniqueness checks against a backend endpoint.
+
+```dart
+Unique(
+  String endpoint, {
+  required String field,
+  Duration debounce = const Duration(milliseconds: 400),
+});
+
+Unique.via(UniqueResolver resolver);  // swap HTTP for custom/in-memory resolver (testing)
+
+typedef UniqueResolver = Future<bool> Function(String endpoint, String field, dynamic value);
+```
+
+Behavior:
+- **Debounced** per-instance (default 400ms) — rapid typing coalesces into one network call. Pass `Duration.zero` to disable.
+- **Stale-in-flight discard** — if a new request starts while one is pending, the stale result is ignored.
+- **Network-error tolerant** — errors log and pass (`true`) so the server stays authoritative on submit. The `Log.error()` call records context.
+- **Null/empty short-circuit** — null and whitespace-only strings pass; that's `Required`'s job.
+
+### Usage
+
+```dart
+final rules = {
+  'email': [Required(), Email(), Unique('/users', field: 'email')],
+};
+
+final validated = await Validator.make(data, rules).validateAsync();
+// Throws ValidationException on failure.
+// Sync rules run first; async rules run only for fields that passed sync.
+```
+
+Swap the resolver for tests or non-HTTP backends:
+
+```dart
+final rule = Unique('/users', field: 'email')
+  .via((endpoint, field, value) async => !_taken.contains(value));
+```

--- a/skills/magic-framework/references/routing-navigation.md
+++ b/skills/magic-framework/references/routing-navigation.md
@@ -91,7 +91,7 @@ MagicRoute.group(
 
 ## Resource Routes (ResourceController)
 
-`MagicRoute.resource(name, controller, {only, except})` auto-wires up to four canonical GET routes to a controller that mixes in `ResourceController`. Each generated `RouteDefinition` gets an auto-assigned `{slug}.{method}` name and title (slug derived from `name`, so nested paths like `/admin/users` become `admin-users.index`).
+`MagicRoute.resource(name, controller, {only, except})` auto-wires up to four canonical GET routes to a controller that mixes in `ResourceController`. Each generated `RouteDefinition` gets an auto-assigned `{slug}.{method}` name and title (slug is the normalized `name`, so a nested path like `/admin/users` produces `admin/users.index`).
 
 ```dart
 static List<RouteDefinition> MagicRoute.resource(

--- a/skills/magic-framework/references/routing-navigation.md
+++ b/skills/magic-framework/references/routing-navigation.md
@@ -89,6 +89,64 @@ MagicRoute.group(
 | `layoutId` | `String?` | Layout identifier for merging groups with same layout |
 | `routes` | `void Function()` | Callback to register child routes |
 
+## Resource Routes (ResourceController)
+
+`MagicRoute.resource(name, controller, {only, except})` auto-wires up to four canonical GET routes to a controller that mixes in `ResourceController`. Each generated `RouteDefinition` gets an auto-assigned `{slug}.{method}` name and title (slug derived from `name`, so nested paths like `/admin/users` become `admin-users.index`).
+
+```dart
+static List<RouteDefinition> MagicRoute.resource(
+  String name,
+  ResourceController controller, {
+  List<String>? only,      // whitelist of methods
+  List<String>? except,    // blacklist of methods
+});
+```
+
+### Generated routes
+
+| Path | HTTP-style method | ResourceController hook |
+|------|-------------------|-------------------------|
+| `GET /{name}` | `index` | `Widget index()` |
+| `GET /{name}/create` | `create` | `Widget create()` |
+| `GET /{name}/:id` | `show` | `Widget show(String id)` |
+| `GET /{name}/:id/edit` | `edit` | `Widget edit(String id)` |
+
+### ResourceController mixin
+
+```dart
+mixin ResourceController {
+  /// Override to expose only a subset. Default: {'index', 'create', 'show', 'edit'}.
+  Set<String> get resourceMethods => const {'index', 'create', 'show', 'edit'};
+
+  Widget index() => throw UnimplementedError();
+  Widget create() => throw UnimplementedError();
+  Widget show(String id) => throw UnimplementedError();
+  Widget edit(String id) => throw UnimplementedError();
+}
+```
+
+### Usage
+
+```dart
+class UserRoutes with ResourceController {
+  @override Set<String> get resourceMethods => {'index', 'create', 'show', 'edit'};
+  @override Widget index() => const UserListView();
+  @override Widget create() => const UserCreateView();
+  @override Widget show(String id) => UserShowView(id: id);
+  @override Widget edit(String id) => UserEditView(id: id);
+}
+
+// In RouteServiceProvider.register():
+MagicRoute.resource('users', UserRoutes());                         // all four methods
+MagicRoute.resource('posts', PostRoutes(), only: ['index', 'show']); // read-only
+MagicRoute.resource('teams', TeamRoutes(), except: ['edit']);       // all except edit
+```
+
+Resolution rules:
+- `name` is normalized — collapses repeated slashes, strips leading/trailing slashes.
+- `only` / `except` narrow the set further, but only **within** `resourceMethods` (so a controller that lists `['index', 'show']` cannot expose `edit` even via `only`).
+- Unknown method names in `only` or `except` throw `ArgumentError` at registration time, not at navigation.
+
 ## Persistent Layouts (Shell Routes)
 
 Use layouts to maintain persistent UI (tabs, navigation rails, sidebars) while child routes change.

--- a/skills/magic-framework/references/secondary-systems.md
+++ b/skills/magic-framework/references/secondary-systems.md
@@ -299,7 +299,19 @@ Laravel-style flash data for form repopulation and transient messages. Two inter
 - `_next` — receives `flash()` / `flashErrors()` writes during the current frame.
 - `_current` — read by `old()`, `error()`, `hasError()`, `hasFlash`.
 
-`Session.tick()` promotes `_next` → `_current` and is called automatically by the router on every navigation. Each value therefore survives exactly one navigation hop.
+`Session.tick()` promotes `_next` → `_current`. The framework does **not** tick automatically — wire a routerDelegate listener gated on real `MagicRouter.instance.currentLocation` changes during bootstrap (GoRouter fires `routerDelegate` notifications for non-navigation rebuilds too, which would prematurely burn the flash). Each value then survives exactly one navigation hop.
+
+```dart
+// Call once during app bootstrap (e.g. in a ServiceProvider.boot()):
+var lastLocation = MagicRouter.instance.currentLocation;
+MagicRouter.instance.router.routerDelegate.addListener(() {
+  final current = MagicRouter.instance.currentLocation;
+  if (current != lastLocation) {
+    Session.tick();
+    lastLocation = current;
+  }
+});
+```
 
 ### API
 
@@ -313,7 +325,7 @@ Laravel-style flash data for form repopulation and transient messages. Two inter
 | `Session.errors(String field)` | `List<String>` | All current-bucket errors for field |
 | `Session.hasError(String field)` | `bool` | True if field has at least one current-bucket error |
 | `Session.hasFlash` | `bool` | **Getter.** Any readable flash data this frame |
-| `Session.tick()` | `void` | Promote next → current (router hook) |
+| `Session.tick()` | `void` | Promote next → current. Not auto-wired — attach at bootstrap (snippet above) |
 | `Session.reset()` | `void` | Clear both buckets (testing) |
 | `Session.setStore(SessionStore store)` | `void` | Swap backing store (testing) |
 
@@ -326,7 +338,7 @@ String? error(String field);
 
 ### Auto-flash on validation failure
 
-`MagicFormData.validate()` calls `Session.flash(form.data)` + `Session.flashErrors(...)` automatically when client-side validation fails. Typical flow:
+`MagicFormData.validate()` calls `Session.flash(form.data)` automatically when client-side validation fails. Per-field validation errors are **not** auto-flashed — call `Session.flashErrors(...)` manually (e.g. from a server response) if you need `error('field')` to resolve after navigation. Typical flow:
 
 ```dart
 // Submit view:

--- a/skills/magic-framework/references/secondary-systems.md
+++ b/skills/magic-framework/references/secondary-systems.md
@@ -292,6 +292,99 @@ Translation files use `:attribute` placeholders:
 }
 ```
 
+## Session (Flash Store)
+
+Laravel-style flash data for form repopulation and transient messages. Two internal buckets:
+
+- `_next` — receives `flash()` / `flashErrors()` writes during the current frame.
+- `_current` — read by `old()`, `error()`, `hasError()`, `hasFlash`.
+
+`Session.tick()` promotes `_next` → `_current` and is called automatically by the router on every navigation. Each value therefore survives exactly one navigation hop.
+
+### API
+
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `Session.flash(Map<String, dynamic> input)` | `void` | Flash inputs for next hop (merged, not replaced) |
+| `Session.flashErrors(Map<String, List<String>> errors)` | `void` | Flash per-field validation errors (merged) |
+| `Session.old(String field, [String? fallback])` | `String?` | Current-bucket input as string. Fallback returns only if the key was never flashed; explicit null flash returns `null` |
+| `Session.oldRaw(String field)` | `dynamic` | Current-bucket raw, non-stringified value |
+| `Session.error(String field)` | `String?` | First current-bucket error for field |
+| `Session.errors(String field)` | `List<String>` | All current-bucket errors for field |
+| `Session.hasError(String field)` | `bool` | True if field has at least one current-bucket error |
+| `Session.hasFlash` | `bool` | **Getter.** Any readable flash data this frame |
+| `Session.tick()` | `void` | Promote next → current (router hook) |
+| `Session.reset()` | `void` | Clear both buckets (testing) |
+| `Session.setStore(SessionStore store)` | `void` | Swap backing store (testing) |
+
+Top-level helpers (mirror Laravel's Blade API):
+
+```dart
+String? old(String field, [String? fallback]);
+String? error(String field);
+```
+
+### Auto-flash on validation failure
+
+`MagicFormData.validate()` calls `Session.flash(form.data)` + `Session.flashErrors(...)` automatically when client-side validation fails. Typical flow:
+
+```dart
+// Submit view:
+void _submit() {
+  if (!form.validate()) return;  // on failure: data + errors are flashed
+  form.process(() => controller.save(form.data));
+}
+
+// Next view (re-entered via MagicRoute.back or similar) repopulates:
+class UserFormView extends MagicStatefulView<UserController> { ... }
+class _UserFormViewState extends MagicStatefulViewState<UserController, UserFormView> {
+  late final form = MagicFormData({
+    'email': old('email') ?? '',
+    'name': old('name') ?? '',
+  }, controller: controller);
+
+  @override Widget build(BuildContext context) => Column(children: [
+    TextField(
+      controller: form['email'],
+      decoration: InputDecoration(errorText: error('email')),
+    ),
+  ]);
+}
+```
+
+### Manual flash from a controller
+
+```dart
+Future<void> store(Map<String, dynamic> data) async {
+  final response = await Http.post('/users', data: data);
+  if (!response.successful) {
+    Session.flash(data);
+    Session.flashErrors(response.errors);
+    MagicRoute.back();
+    return;
+  }
+  // ...
+}
+```
+
+### Testing
+
+```dart
+setUp(() {
+  MagicApp.reset();
+  Magic.flush();
+  Session.reset();              // clear both buckets
+});
+
+test('flash survives one tick', () {
+  Session.flash({'email': 'foo@bar.com'});
+  Session.tick();
+  expect(Session.old('email'), 'foo@bar.com');
+  Session.tick();                // second tick — current bucket now empty
+  expect(Session.old('email'), isNull);
+});
+```
+
 ## Storage Manager
 
 File system abstraction for local disk operations. Supports multiple disks (local, public) and handles platform differences (mobile vs. web). Accessed via the `Storage` facade.


### PR DESCRIPTION
## Summary
- Update `skills/magic-framework/SKILL.md` and six references to cover the seven features merged on top of `1.0.0-alpha.13`:
  - **Eloquent**: `CastsAttributes` contract, `EnumCast`, `ListCast`, json Map/List round-trip, `Model.fill(strict: true)`, `MassAssignmentException` (#73, #74)
  - **Validation**: `FormRequest` (authorize → prepared → validate), `AuthorizationException`, `AsyncRule` contract + `Unique(endpoint, field:)` with debounce/stale-discard/error-tolerant behavior, `Validator.validateAsync()` (#75, #78)
  - **HTTP/Auth**: `MagicController.authorize(ability)`, `Gate.allowsAny` / `Gate.allowsAll` short-circuiting helpers (#76)
  - **Routing**: `MagicRoute.resource(name, controller, {only, except})` + `ResourceController` mixin with auto-assigned `{slug}.{method}` names (#77)
  - **Session**: `Session` facade with flash data, two-bucket store, `old()` / `error()` top-level helpers, `MagicFormData.validate()` auto-flash on failure (#79)
- Bump facade count from 17 → 18, refresh triggers, canonical patterns, anti-patterns, and reference index

## Test plan
- [ ] Skim `SKILL.md` — new canonical patterns section (FormRequest, Resource Routing, Async Validation, Session Flash) renders cleanly
- [ ] Confirm each referenced symbol exists in master (`EnumCast`, `ListCast`, `FormRequest`, `ResourceController`, `Gate.allowsAny`, `Session.old`, etc.)
- [ ] Remember to mirror these changes to the [`fluttersdk/ai`](https://github.com/fluttersdk/ai) repo (`skills/magic-framework/` path) after merge