### PR TITLE
chore: add registry dispatch workflow

### DIFF
--- a/.github/workflows/dispatch-to-registry.yml
+++ b/.github/workflows/dispatch-to-registry.yml
@@ -53,11 +53,11 @@ jobs:
               id: app-token
               uses: tibdex/github-app-token@v2.1.0
               with:
-                app_id: ${{ secrets.REGISTRY_BOT_APP_ID }}
-                private_key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
-                installation_retrieval_mode: repository
-                installation_retrieval_payload: fluttersdk/ai
-                repositories: '["ai"]'
+                  app_id: ${{ secrets.REGISTRY_BOT_APP_ID }}
+                  private_key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
+                  installation_retrieval_mode: repository
+                  installation_retrieval_payload: fluttersdk/ai
+                  repositories: '["ai"]'
 
             - name: Fire repository_dispatch to fluttersdk/ai
               uses: peter-evans/repository-dispatch@v4

--- a/.github/workflows/dispatch-to-registry.yml
+++ b/.github/workflows/dispatch-to-registry.yml
@@ -51,12 +51,13 @@ jobs:
 
             - name: Mint App token scoped to fluttersdk/ai
               id: app-token
-              uses: actions/create-github-app-token@v3.1.1
+              uses: tibdex/github-app-token@v2.1.0
               with:
-                  app-id: ${{ secrets.REGISTRY_BOT_APP_ID }}
-                  private-key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
-                  owner: fluttersdk
-                  repositories: ai
+                app_id: ${{ secrets.REGISTRY_BOT_APP_ID }}
+                private_key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
+                installation_retrieval_mode: repository
+                installation_retrieval_payload: fluttersdk/ai
+                repositories: '["ai"]'
 
             - name: Fire repository_dispatch to fluttersdk/ai
               uses: peter-evans/repository-dispatch@v4

--- a/.github/workflows/dispatch-to-registry.yml
+++ b/.github/workflows/dispatch-to-registry.yml
@@ -35,10 +35,17 @@ jobs:
             - name: Extract version
               id: ver
               run: |
+                  set -euo pipefail
                   if [[ -n "${GITHUB_REF_NAME}" && "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
                       VER="${GITHUB_REF_NAME#v}"
                   else
                       VER=$(grep -E '^version:' pubspec.yaml | head -1 | awk '{print $2}')
+                  fi
+                  # Strip Dart/Flutter build metadata suffix (e.g. 1.2.3+4 -> 1.2.3)
+                  VER="${VER%%+*}"
+                  if [[ -z "$VER" ]]; then
+                      echo "::error::could not extract a non-empty version from ref or pubspec.yaml"
+                      exit 1
                   fi
                   echo "version=$VER" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/dispatch-to-registry.yml
+++ b/.github/workflows/dispatch-to-registry.yml
@@ -1,0 +1,65 @@
+# Auto-sync FlutterSDK AI registry on skill changes.
+#
+# Fires repository_dispatch at fluttersdk/ai when this repo's skill subtree or
+# pubspec.yaml changes on master, or on tag push. The registry's sync.yml
+# receives the event, pulls this subtree, bumps the version triplet, and
+# pushes back to main.
+#
+# Auth: uses the fluttersdk-registry GitHub App (1-hour mint-on-demand tokens)
+# instead of a personal PAT. Requires REGISTRY_BOT_APP_ID + REGISTRY_BOT_PRIVATE_KEY
+# secrets on this repo (same values as on fluttersdk/ai).
+
+name: Dispatch skill update to registry
+
+on:
+    push:
+        branches: [master]
+        paths:
+            - "skills/magic-framework/**"
+            - "pubspec.yaml"
+    release:
+        types: [published]
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    dispatch:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
+
+            - name: Extract version
+              id: ver
+              run: |
+                  if [[ -n "${GITHUB_REF_NAME}" && "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+                      VER="${GITHUB_REF_NAME#v}"
+                  else
+                      VER=$(grep -E '^version:' pubspec.yaml | head -1 | awk '{print $2}')
+                  fi
+                  echo "version=$VER" >> "$GITHUB_OUTPUT"
+
+            - name: Mint App token scoped to fluttersdk/ai
+              id: app-token
+              uses: actions/create-github-app-token@v3
+              with:
+                  app-id: ${{ secrets.REGISTRY_BOT_APP_ID }}
+                  private-key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}
+                  owner: fluttersdk
+                  repositories: ai
+
+            - name: Fire repository_dispatch to fluttersdk/ai
+              uses: peter-evans/repository-dispatch@v4
+              with:
+                  token: ${{ steps.app-token.outputs.token }}
+                  repository: fluttersdk/ai
+                  event-type: skill-updated
+                  client-payload: |
+                      {
+                          "source": "magic",
+                          "version": "${{ steps.ver.outputs.version }}",
+                          "sha": "${{ github.sha }}"
+                      }

--- a/.github/workflows/dispatch-to-registry.yml
+++ b/.github/workflows/dispatch-to-registry.yml
@@ -51,7 +51,7 @@ jobs:
 
             - name: Mint App token scoped to fluttersdk/ai
               id: app-token
-              uses: actions/create-github-app-token@v3
+              uses: actions/create-github-app-token@v3.1.1
               with:
                   app-id: ${{ secrets.REGISTRY_BOT_APP_ID }}
                   private-key: ${{ secrets.REGISTRY_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Adds `.github/workflows/dispatch-to-registry.yml`. When this repo's skill subtree or pubspec.yaml changes on master (or on tag push / manual dispatch), this workflow fires `repository_dispatch` at fluttersdk/ai. The registry's `sync.yml` receives the event, pulls this subtree, bumps the version triplet, and pushes back to main.

**Auth**: uses the `fluttersdk-registry` GitHub App (org-installed). The required secrets `REGISTRY_BOT_APP_ID` and `REGISTRY_BOT_PRIVATE_KEY` have already been added to this repo. No personal access tokens; tokens mint-on-demand with 1-hour TTL.

**Trigger paths**:
- `skills/<name>/**`
- `pubspec.yaml`
- Tag push matching `v*`
- Manual `workflow_dispatch` from Actions UI

**Verification after merge**:
- Trigger via Actions → 'Dispatch skill update to registry' → Run workflow
- Watch fluttersdk/ai Actions → 'Sync Skill From Upstream' should fire
- Confirm a commit lands on fluttersdk/ai `main` bumping the registry version

Plan reference: https://github.com/fluttersdk/ai/blob/main/docs/UPSTREAM-SETUP.md