### PR TITLE
fix(auth): gate restore warning on stored session + correct devtools dep guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project will be documented in this file.
 - [ ] `example/` updated when the change touches the canonical consumer scaffold
 - [ ] `flutter test` green; `dart analyze` clean; `dart format` no diff; `dart pub publish --dry-run` no blocking errors
 
+### Fixed
+
+- **Auth no longer warns on every boot of a fresh app.** `AuthServiceProvider.boot()` logged a `userFactory not registered` warning (blaming provider order) whenever no userFactory was set, even for apps with no stored session to restore. It now only warns when a stored session actually exists (`Auth.hasToken()`) but cannot be rebuilt; a fresh app or a logged-out user stays quiet (debug-level). Touches `lib/src/auth/auth_service_provider.dart`; adds two cases to `test/auth/auth_test.dart`.
+
+### Changed
+
+- **Debug-tooling install guidance corrected to regular `dependencies`.** The `magic:install` post-install message recommended adding `magic_devtools` / `fluttersdk_dusk` / `fluttersdk_telescope` to `dev_dependencies`, but the install commands wire them into `lib/main.dart` (under `kDebugMode`), which trips the `depend_on_referenced_packages` lint. They are now documented as regular `dependencies` (tree-shaken from release via `kDebugMode`), matching dusk/telescope's own install docs. Also bumps the message's stale `fluttersdk_dusk ^0.0.7` to `^0.0.8`. Touches `install.yaml`.
+
 ## [0.0.3] - 2026-06-17
 
 ### Stabilization (magic-stabilize-dusk-telescope plan)

--- a/install.yaml
+++ b/install.yaml
@@ -113,11 +113,12 @@ post_install:
     exception, model, gate watchers). Both gate on kDebugMode so production
     builds tree-shake them entirely.
 
-    The Magic adapters live in the sibling `magic_devtools` package. To
-    enable, add it (plus the tooling packages) to dev_dependencies:
+    The Magic adapters live in the sibling `magic_devtools` package. They are
+    wired into lib/main.dart under kDebugMode (release builds tree-shake them),
+    so add them to dependencies, not dev_dependencies (lib/ imports them):
 
        magic_devtools: ^0.0.1
-       fluttersdk_dusk: ^0.0.7
+       fluttersdk_dusk: ^0.0.8
        fluttersdk_telescope: ^0.0.4
 
     Then:

--- a/lib/src/auth/auth_service_provider.dart
+++ b/lib/src/auth/auth_service_provider.dart
@@ -35,15 +35,23 @@ class AuthServiceProvider extends ServiceProvider {
 
     if (!autoRefresh) return;
 
-    // Guard: userFactory must be registered before restore.
-    // AppServiceProvider.boot() calls Auth.manager.setUserFactory()
-    // and MUST be listed before AuthServiceProvider in app.providers.
+    // A userFactory is required to rebuild the user from a stored session.
+    // Only warn when there is actually a session to restore: a fresh app (or
+    // a user who never logged in) has no stored token, so restore is a no-op
+    // and a warning would just be boot noise on every launch.
     if (!Auth.manager.hasUserFactory) {
-      Log.warning(
-        'Auth: Cannot restore session — userFactory not registered. '
-        'Ensure AppServiceProvider is listed BEFORE AuthServiceProvider '
-        'in your app.providers config.',
-      );
+      if (await Auth.hasToken()) {
+        Log.warning(
+          'Auth: a stored session exists but cannot be restored — no '
+          'userFactory registered. Register it in AppServiceProvider.boot() '
+          'via Auth.manager.setUserFactory(...), and list AppServiceProvider '
+          'before AuthServiceProvider in app.providers.',
+        );
+      } else {
+        Log.debug(
+          'Auth: no userFactory and no stored session; skipping restore.',
+        );
+      }
       return;
     }
 

--- a/test/auth/auth_test.dart
+++ b/test/auth/auth_test.dart
@@ -89,6 +89,50 @@ class MockGuard implements Guard {
 // ---------------------------------------------------------------------------
 
 void main() {
+  group('AuthServiceProvider restore-warning gating', () {
+    setUp(() {
+      MagicApp.reset();
+      Magic.flush();
+    });
+
+    tearDown(() {
+      Log.unfake();
+      Vault.unfake();
+      MagicApp.reset();
+      Magic.flush();
+    });
+
+    test(
+      'stays quiet when there is no userFactory and no stored session',
+      () async {
+        final log = Log.fake();
+        Vault.fake(); // empty vault → guard.hasToken() is false
+
+        await (AuthServiceProvider(MagicApp.instance)..register()).boot();
+
+        final warnedAboutFactory = log.entries.any(
+          (e) => e.level == 'warning' && e.message.contains('userFactory'),
+        );
+        expect(warnedAboutFactory, isFalse);
+      },
+    );
+
+    test(
+      'warns when a stored session exists but no userFactory is registered',
+      () async {
+        final log = Log.fake();
+        Vault.fake({'auth_token': 'stored-token'}); // a session to restore
+
+        await (AuthServiceProvider(MagicApp.instance)..register()).boot();
+
+        final warnedAboutFactory = log.entries.any(
+          (e) => e.level == 'warning' && e.message.contains('userFactory'),
+        );
+        expect(warnedAboutFactory, isTrue);
+      },
+    );
+  });
+
   group('Authenticatable Mixin', () {
     test('authIdentifier returns primary key value', () {
       final user = MockUser()


### PR DESCRIPTION
Fixes two findings surfaced by a fresh-app E2E test of magic + magic_devtools + dusk + telescope.

**1. Auth boot warning noise.** `AuthServiceProvider.boot()` logged `userFactory not registered` (and misleadingly blamed provider order) on every boot of a fresh app, even when there was no stored session to restore. Now it only warns when `Auth.hasToken()` is true but no userFactory is registered (a genuine misconfig); a fresh app or logged-out user stays quiet (debug-level). +2 regression tests in `test/auth/auth_test.dart`.

**2. Debug-tooling dep guidance.** The `magic:install` post-install message recommended `dev_dependencies` for magic_devtools/dusk/telescope, but the install commands import them in `lib/main.dart`, tripping `depend_on_referenced_packages` (4 infos on every fresh install). Corrected to regular `dependencies` (tree-shaken from release via `kDebugMode`), matching dusk/telescope's own install docs; also bumps stale `^0.0.7` -> `^0.0.8`.

Verified: full suite 1145 green, analyze clean, format clean; fresh-app re-test with regular deps -> `flutter analyze` = No issues found.