### PR TITLE
docs: make `dart run magic:artisan` the canonical CLI invocation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,10 @@ Standard Flutter commands (`flutter test`, `dart analyze`, `dart format .`, `flu
 | `flutter test --coverage` | Tests + `coverage/lcov.info` (CI uploads to codecov) |
 | `flutter test test/<module>` | Single module |
 | `dart pub publish --dry-run` | Pre-release validation |
-| `dart run <app>:artisan magic:install` | One-shot consumer bootstrap (hybrid installer) |
-| `dart run <app>:artisan make:model User -mcf` | Generators: 14 `make:*` + `key:generate` |
+| `dart run magic:artisan magic:install` | One-shot consumer bootstrap (hybrid installer) |
+| `dart run magic:artisan make:model User -mcf` | Generators: 14 `make:*` + `key:generate` |
 
-Magic's CLI is an `fluttersdk_artisan` plugin (`MagicArtisanProvider`); a consumer runs it through its own artisan dispatcher (`dart run <app>:artisan <cmd>`), not as a global activate. There is no standalone magic executable beyond the artisan plugin surface.
+Magic ships an `artisan` executable (`pubspec.yaml` `executables: { artisan: }`, backed by `bin/artisan.dart`), so a consumer runs any command with `dart run magic:artisan <cmd>` once `magic` is a dependency: no global activate, no app-specific package name. `MagicArtisanProvider` supplies the commands; it also plugs into a consumer app's own aggregated artisan dispatcher when one exists.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ final user = await User.find(1);
 
 ## Quick Start
 
-Magic ships with a full Artisan-style CLI driven by the `fluttersdk_artisan` package. The canonical install is a one-shot `plugin:install magic` command that scaffolds all config files, service providers, environment files, and bootstraps `lib/main.dart`.
+Magic ships an `artisan` executable (declared in its `pubspec.yaml`), so once you add `magic` as a dependency its full Artisan-style CLI is available via `dart run magic:artisan <command>` with no global activation and no per-app wrapper to write. The canonical bootstrap is the one-shot `magic:install` command, which scaffolds all config files, service providers, environment files, and the `lib/main.dart` bootstrap.
 
 ### 1. Create a Flutter project
 
@@ -88,34 +88,12 @@ dependency_overrides:
     path: ../fluttersdk_artisan
 ```
 
-### 3. Create `bin/artisan.dart`
+### 3. Run the one-shot install
 
-Magic commands are registered through the Artisan registry. Create a minimal wrapper:
-
-```dart
-import 'dart:io';
-import 'package:fluttersdk_artisan/artisan.dart';
-import 'package:magic/cli.dart' show MagicArtisanProvider;
-
-Future<void> main(List<String> args) async {
-  final registry = ArtisanRegistry();
-  registry.registerAll(<ArtisanCommand>[
-    StartCommand(),
-    StopCommand(),
-    ListCommand(registry),
-    HelpCommand(registry),
-    PluginInstallCommand(),
-    PluginUninstallCommand(),
-  ], providerName: 'fluttersdk_artisan');
-  registry.registerProvider(MagicArtisanProvider());
-  exit(await ArtisanApplication(registry: registry).dispatch(args));
-}
-```
-
-### 4. Run the one-shot install
+Magic bundles its own `artisan` executable, so there is nothing to wire up by hand: run the installer directly.
 
 ```bash
-dart run :artisan magic:install --force --non-interactive
+dart run magic:artisan magic:install --force --non-interactive
 ```
 
 Use `magic:install` (not `plugin:install magic`) for the one-shot bootstrap: it runs the full hybrid installer (`main.dart` Magic.init() bootstrap + all config files + the dispatcher/fastcli scaffold). `plugin:install magic` only applies the static manifest layer (provider registration + config publish) and does NOT rewrite `main.dart`, so a fresh project installed that way will not boot into Magic. See [Install paths](#install-paths) below.
@@ -126,13 +104,13 @@ The command scaffolds: `lib/config/` (9 config files), `lib/app/providers/` (rou
 
 > **Note on sqlite3.wasm (web target):** Magic's SQLite driver requires `web/sqlite3.wasm` on Flutter web. V1 does not auto-download this file. If you target Flutter web with the SQLite driver, manually download `sqlite3.wasm` from the sqlite3.dart releases (match the version in `pubspec.lock`) and place it in `web/`.
 
-### 5. Generate the app key
+### 4. Generate the app key
 
 ```bash
-dart run :artisan key:generate
+dart run magic:artisan key:generate
 ```
 
-### 6. Install dependencies and run
+### 5. Install dependencies and run
 
 ```bash
 flutter pub get && flutter run
@@ -158,7 +136,7 @@ When `--non-interactive` is absent, the installer prompts for each option intera
 Example: install without database and broadcasting:
 
 ```bash
-dart run :artisan magic:install --force --without-database --without-broadcasting
+dart run magic:artisan magic:install --force --without-database --without-broadcasting
 ```
 
 The `--without-X` flags are honored by `magic:install` (the hybrid command); they are not part of the static `plugin:install` manifest flow.
@@ -167,8 +145,8 @@ The `--without-X` flags are honored by `magic:install` (the hybrid command); the
 
 Two entrypoints exist; they are NOT equivalent:
 
-- **`dart run :artisan magic:install`** (recommended, full bootstrap): runs `MagicInstallCommand`, the hybrid installer. It publishes every config file, rewrites `lib/main.dart` with the `Magic.init()` bootstrap + `configFactories`, scaffolds the dispatcher + fastcli, and honors the `--without-X` flags. This is what a fresh project needs to boot into Magic.
-- **`dart run :artisan plugin:install magic`** (static layer only): routes through artisan's manifest installer. It registers the provider and publishes the static config templates, but does NOT run the dynamic `main.dart` bootstrap. Use it only to (re)apply the manifest layer on a project that is already Magic-bootstrapped.
+- **`dart run magic:artisan magic:install`** (recommended, full bootstrap): runs `MagicInstallCommand`, the hybrid installer. It publishes every config file, rewrites `lib/main.dart` with the `Magic.init()` bootstrap + `configFactories`, scaffolds the dispatcher + fastcli, and honors the `--without-X` flags. This is what a fresh project needs to boot into Magic.
+- **`dart run magic:artisan plugin:install magic`** (static layer only): routes through artisan's manifest installer. It registers the provider and publishes the static config templates, but does NOT run the dynamic `main.dart` bootstrap. Use it only to (re)apply the manifest layer on a project that is already Magic-bootstrapped.
 
 ### Build your first controller
 
@@ -451,23 +429,23 @@ WDiv(
 ## CLI Commands
 
 ```bash
-dart run magic:magic make:model User -mcf        # Model + migration + controller + factory
-dart run magic:magic make:controller User         # Controller
-dart run magic:magic make:view Login              # View class
-dart run magic:magic make:migration create_users  # Migration
-dart run magic:magic make:seeder UserSeeder       # Database seeder
-dart run magic:magic make:policy Post             # Authorization policy
-dart run magic:magic make:provider Payment        # Service provider
-dart run magic:magic make:event OrderShipped      # Event class
-dart run magic:magic make:listener SendEmail      # Event listener
-dart run magic:magic make:middleware Auth          # Middleware
-dart run magic:magic make:request StoreUser       # Form request
-dart run magic:magic make:lang tr                 # Language file
-dart run magic:magic make:enum Status             # Enum class
+dart run magic:artisan make:model User -mcf        # Model + migration + controller + factory
+dart run magic:artisan make:controller User         # Controller
+dart run magic:artisan make:view Login              # View class
+dart run magic:artisan make:migration create_users  # Migration
+dart run magic:artisan make:seeder UserSeeder       # Database seeder
+dart run magic:artisan make:policy Post             # Authorization policy
+dart run magic:artisan make:provider Payment        # Service provider
+dart run magic:artisan make:event OrderShipped      # Event class
+dart run magic:artisan make:listener SendEmail      # Event listener
+dart run magic:artisan make:middleware Auth          # Middleware
+dart run magic:artisan make:request StoreUser       # Form request
+dart run magic:artisan make:lang tr                 # Language file
+dart run magic:artisan make:enum Status             # Enum class
 ```
 
 > [!TIP]
-> If you activated the CLI globally (`dart pub global activate magic_cli`), you can use the shorter `magic <command>` syntax instead.
+> Every command runs via `dart run magic:artisan <command>` once `magic` is a dependency. There is no separate `magic_cli` package to activate globally.
 
 ## Testing
 

--- a/doc/basics/controllers.md
+++ b/doc/basics/controllers.md
@@ -28,7 +28,7 @@ Instead of defining all of your request handling logic as closures in your route
 To generate a new controller, use the `make:controller` Magic CLI command:
 
 ```bash
-dart run <app>:artisan make:controller User
+dart run magic:artisan make:controller User
 ```
 
 A basic controller extends `MagicController` and contains action methods that return widgets:
@@ -309,16 +309,16 @@ The Magic CLI can generate controllers with various options:
 
 ```bash
 # Basic controller
-dart run <app>:artisan make:controller User
+dart run magic:artisan make:controller User
 
 # Resource controller with CRUD actions and views
-dart run <app>:artisan make:controller Product --resource
+dart run magic:artisan make:controller Product --resource
 
 # Nested in subfolder
-dart run <app>:artisan make:controller Admin/Dashboard
+dart run magic:artisan make:controller Admin/Dashboard
 
 # Resource controller with model binding
-dart run <app>:artisan make:controller Post --resource --model=Post
+dart run magic:artisan make:controller Post --resource --model=Post
 ```
 
 ### Command Options
@@ -349,7 +349,7 @@ When using `--resource`, the command generates a full resource controller with:
 Example:
 
 ```bash
-dart run <app>:artisan make:controller Task --resource
+dart run magic:artisan make:controller Task --resource
 ```
 
 This generates a TaskController with all CRUD actions and four corresponding views.

--- a/doc/basics/forms.md
+++ b/doc/basics/forms.md
@@ -27,7 +27,7 @@ Magic provides a complete form handling system: `MagicFormData` for centralized 
 Magic provides a powerful form handling system that combines the simplicity of Laravel's request handling with Flutter's form widgets. Forms are managed through `MagicFormData`, which centralizes form state, validation, and data extraction.
 
 > [!TIP]
-> You can generate a validated form request stub using the Magic CLI: `dart run <app>:artisan make:request` (e.g., `dart run <app>:artisan make:request StoreOrder`). The generated file at `lib/app/requests/store_order_request.dart` provides a structured place for your validation rules.
+> You can generate a validated form request stub using the Magic CLI: `dart run magic:artisan make:request` (e.g., `dart run magic:artisan make:request StoreOrder`). The generated file at `lib/app/requests/store_order_request.dart` provides a structured place for your validation rules.
 
 <a name="magicformdata"></a>
 ## MagicFormData

--- a/doc/basics/middleware.md
+++ b/doc/basics/middleware.md
@@ -24,7 +24,7 @@ Of course, additional middleware can be written to perform a variety of tasks be
 Use the Magic CLI to generate a new middleware class:
 
 ```bash
-dart run <app>:artisan make:middleware Auth
+dart run magic:artisan make:middleware Auth
 ```
 
 This creates `lib/app/middleware/auth.dart` with a `MagicMiddleware` stub ready to implement.

--- a/doc/basics/views.md
+++ b/doc/basics/views.md
@@ -29,7 +29,7 @@ Magic Views provide a structured way to separate your UI from your business logi
 To generate a new view, use the Magic CLI:
 
 ```bash
-dart run <app>:artisan make:view Dashboard
+dart run magic:artisan make:view Dashboard
 ```
 
 <a name="stateless-views"></a>
@@ -238,13 +238,13 @@ The Magic CLI can generate different types of views:
 
 ```bash
 # Basic stateless view
-dart run <app>:artisan make:view Dashboard
+dart run magic:artisan make:view Dashboard
 
 # Stateful view with form support
-dart run <app>:artisan make:view Auth/Login --stateful
+dart run magic:artisan make:view Auth/Login --stateful
 
 # Nested in subfolder
-dart run <app>:artisan make:view Admin/Users/Index
+dart run magic:artisan make:view Admin/Users/Index
 ```
 
 ### Command Options

--- a/doc/database/migrations.md
+++ b/doc/database/migrations.md
@@ -24,9 +24,9 @@ Migrations are like version control for your database, allowing your team to def
 Use the `make:migration` command to generate a migration:
 
 ```bash
-dart run <app>:artisan make:migration create_users_table
-dart run <app>:artisan make:migration CreateUsersTable    # PascalCase also works
-dart run <app>:artisan make:migration add_avatar_to_users
+dart run magic:artisan make:migration create_users_table
+dart run magic:artisan make:migration CreateUsersTable    # PascalCase also works
+dart run magic:artisan make:migration add_avatar_to_users
 ```
 
 This creates a file in `lib/database/migrations/` with:

--- a/doc/database/seeding.md
+++ b/doc/database/seeding.md
@@ -50,7 +50,7 @@ await Magic.seed([UserSeeder(), PostSeeder()]);
 Generate a seeder using the CLI:
 
 ```bash
-dart run <app>:artisan make:seeder UserSeeder
+dart run magic:artisan make:seeder UserSeeder
 ```
 
 A seeder class contains a single `run` method which is called when the seeder is executed:
@@ -96,7 +96,7 @@ class DatabaseSeeder extends Seeder {
 Factories define how to generate fake data for a model. Generate a factory using the CLI:
 
 ```bash
-dart run <app>:artisan make:factory User
+dart run magic:artisan make:factory User
 ```
 
 A factory extends `Factory<T>` and defines the model's default attributes:
@@ -223,8 +223,8 @@ await UserFactory().unverified().count(10).create();
 ### Create Seeder
 
 ```bash
-dart run <app>:artisan make:seeder UserSeeder
-dart run <app>:artisan make:seeder User           # Auto-appends 'Seeder'
+dart run magic:artisan make:seeder UserSeeder
+dart run magic:artisan make:seeder User           # Auto-appends 'Seeder'
 ```
 
 **Output:** Creates `lib/database/seeders/user_seeder.dart`
@@ -232,11 +232,11 @@ dart run <app>:artisan make:seeder User           # Auto-appends 'Seeder'
 ### Create Factory
 
 ```bash
-dart run <app>:artisan make:factory User
-dart run <app>:artisan make:factory UserFactory   # Accepts either form
+dart run magic:artisan make:factory User
+dart run magic:artisan make:factory UserFactory   # Accepts either form
 ```
 
 **Output:** Creates `lib/database/factories/user_factory.dart`
 
 > [!TIP]
-> Use the `--all` flag with `make:model` to generate model, migration, seeder, and factory in one command: `dart run <app>:artisan make:model User --all`
+> Use the `--all` flag with `make:model` to generate model, migration, seeder, and factory in one command: `dart run magic:artisan make:model User --all`

--- a/doc/digging-deeper/encryption.md
+++ b/doc/digging-deeper/encryption.md
@@ -26,7 +26,7 @@ APP_KEY=base64:your-32-character-random-key-here
 Generate a new key using the CLI:
 
 ```bash
-dart run <app>:artisan key:generate
+dart run magic:artisan key:generate
 ```
 
 > [!WARNING]

--- a/doc/digging-deeper/events.md
+++ b/doc/digging-deeper/events.md
@@ -30,13 +30,13 @@ await Event.dispatch(OrderShipped(order));
 Use the Magic CLI to scaffold event and listener classes:
 
 ```bash
-dart run <app>:artisan make:event OrderShipped
+dart run magic:artisan make:event OrderShipped
 ```
 
 This creates `lib/app/events/order_shipped.dart` with a `MagicEvent` stub.
 
 ```bash
-dart run <app>:artisan make:listener SendEmail --event=OrderShipped
+dart run magic:artisan make:listener SendEmail --event=OrderShipped
 ```
 
 This creates `lib/app/listeners/send_email.dart` with a `MagicListener<OrderShipped>` stub, pre-wired to the specified event.

--- a/doc/digging-deeper/localization.md
+++ b/doc/digging-deeper/localization.md
@@ -349,9 +349,9 @@ final response = await Http.get('/api/profile');
 ### Create Translation File
 
 ```bash
-dart run <app>:artisan make:lang fr
-dart run <app>:artisan make:lang de
-dart run <app>:artisan make:lang tr
+dart run magic:artisan make:lang fr
+dart run magic:artisan make:lang de
+dart run magic:artisan make:lang tr
 ```
 
 This command:

--- a/doc/eloquent/getting-started.md
+++ b/doc/eloquent/getting-started.md
@@ -27,7 +27,7 @@ Unlike traditional ORMs, Magic's Eloquent supports **Hybrid Persistence**. Your 
 To generate a new model, use the `make:model` Magic CLI command:
 
 ```bash
-dart run <app>:artisan make:model Post
+dart run magic:artisan make:model Post
 ```
 
 ### Available Options
@@ -46,7 +46,7 @@ dart run <app>:artisan make:model Post
 The `-a` flag is the most convenient way to scaffold a complete feature:
 
 ```bash
-dart run <app>:artisan make:model Product --all
+dart run magic:artisan make:model Product --all
 ```
 
 This single command creates:

--- a/doc/getting-started/installation.md
+++ b/doc/getting-started/installation.md
@@ -110,13 +110,13 @@ This pulls in Magic and all its dependencies, including **Wind UI** and the **Ma
 
 ### 2. Scaffold Your Application
 
-The Magic CLI ships as an `fluttersdk_artisan` plugin bundled with the `magic` package. Run it through your app's artisan dispatcher:
+The Magic CLI ships as an `artisan` executable bundled with the `magic` package (declared in its `pubspec.yaml` `executables:`). Run it from any project that depends on magic:
 
 ```bash
-dart run <app>:artisan magic:install
+dart run magic:artisan magic:install
 ```
 
-Replace `<app>` with your Flutter app package name (the `name` field in your `pubspec.yaml`).
+No global activation or package-name substitution is needed: `dart run magic:artisan` resolves magic's bundled executable directly.
 
 This command creates everything you need:
 - `lib/config/` — Configuration files (app, auth, broadcasting, cache, database, network, logging, routing, view)
@@ -130,7 +130,7 @@ This command creates everything you need:
 You can exclude features you don't need:
 
 ```bash
-dart run <app>:artisan magic:install --without-database --without-auth --without-cache
+dart run magic:artisan magic:install --without-database --without-auth --without-cache
 ```
 
 Available flags: `--without-auth`, `--without-database`, `--without-network`, `--without-cache`, `--without-events`, `--without-localization`, `--without-logging`, `--without-broadcasting`. See [Magic CLI](/packages/magic-cli#install) for details.
@@ -138,7 +138,7 @@ Available flags: `--without-auth`, `--without-database`, `--without-network`, `-
 <a name="bootstrapping-your-application"></a>
 ## Bootstrapping Your Application
 
-If you used `dart run <app>:artisan magic:install`, your application is already bootstrapped. The install command generates a ready-to-run `main.dart` and all configuration files. Here's what was created:
+If you used `dart run magic:artisan magic:install`, your application is already bootstrapped. The install command generates a ready-to-run `main.dart` and all configuration files. Here's what was created:
 
 ### Generated Entry Point
 

--- a/doc/getting-started/service-providers.md
+++ b/doc/getting-started/service-providers.md
@@ -26,7 +26,7 @@ If you open the `config/app.dart` file included with Magic, you will see a `prov
 Use the Magic CLI to generate a new service provider class:
 
 ```bash
-dart run <app>:artisan make:provider Payment
+dart run magic:artisan make:provider Payment
 ```
 
 This creates `lib/app/providers/payment_service_provider.dart` with a `ServiceProvider` stub containing empty `register()` and `boot()` methods.

--- a/doc/packages/magic-cli.md
+++ b/doc/packages/magic-cli.md
@@ -1,6 +1,6 @@
 # Magic CLI
 
-The Magic CLI is an `fluttersdk_artisan` plugin that ships as part of the magic package, providing `magic:install`, `key:generate`, and 14 `make:*` scaffold commands run through your app's artisan entrypoint.
+The Magic CLI is an `fluttersdk_artisan` plugin that ships as part of the magic package, providing `magic:install`, `key:generate`, and 14 `make:*` scaffold commands through magic's bundled `artisan` executable (`dart run magic:artisan`).
 
 - [Introduction](#introduction)
 - [Installation](#installation)
@@ -31,7 +31,7 @@ Magic CLI is the Artisan-like command-line tool for Magic. If you've used Larave
 <a name="installation"></a>
 ## Installation
 
-The Magic CLI ships as an `fluttersdk_artisan` plugin bundled with the `magic` package. There is no separate install step. Run commands through your app's artisan dispatcher:
+The Magic CLI ships as an `fluttersdk_artisan` plugin bundled with the `magic` package, which exposes its own `artisan` executable. There is no separate install step: run commands via that executable. (If your app sets up its own aggregated artisan dispatcher, the same commands are available there too.)
 
 ```bash
 dart run magic:artisan <command> [arguments] [options]

--- a/doc/packages/magic-cli.md
+++ b/doc/packages/magic-cli.md
@@ -34,10 +34,10 @@ Magic CLI is the Artisan-like command-line tool for Magic. If you've used Larave
 The Magic CLI ships as an `fluttersdk_artisan` plugin bundled with the `magic` package. There is no separate install step. Run commands through your app's artisan dispatcher:
 
 ```bash
-dart run <app>:artisan <command> [arguments] [options]
+dart run magic:artisan <command> [arguments] [options]
 ```
 
-Replace `<app>` with your Flutter app package name (the `name` field in your `pubspec.yaml`).
+Magic ships the `artisan` executable in its `pubspec.yaml`, so `dart run magic:artisan` works from any project that depends on magic, with no global activation or package-name substitution.
 
 <a name="project-setup"></a>
 ## Project Setup
@@ -48,7 +48,7 @@ Replace `<app>` with your Flutter app package name (the `name` field in your `pu
 Initializes Magic in an existing Flutter project with the recommended directory structure and configuration.
 
 ```bash
-dart run <app>:artisan magic:install
+dart run magic:artisan magic:install
 ```
 
 This command:
@@ -65,8 +65,8 @@ This command:
 You can exclude features you don't need with `--without-*` flags:
 
 ```bash
-dart run <app>:artisan magic:install --without-database
-dart run <app>:artisan magic:install --without-auth --without-events
+dart run magic:artisan magic:install --without-database
+dart run magic:artisan magic:install --without-auth --without-events
 ```
 
 | Flag | What it skips |
@@ -86,7 +86,7 @@ dart run <app>:artisan magic:install --without-auth --without-events
 Generates a random 32-byte encryption key for your application:
 
 ```bash
-dart run <app>:artisan key:generate
+dart run magic:artisan key:generate
 ```
 
 Updates your `.env` file with:
@@ -114,11 +114,11 @@ Commands that auto-append a suffix (Controller, View, Factory, Seeder, Policy, S
 Creates an Eloquent-style model with optional related files:
 
 ```bash
-dart run <app>:artisan make:model User
-dart run <app>:artisan make:model Post --migration --controller --factory
-dart run <app>:artisan make:model Comment -mcf
-dart run <app>:artisan make:model Product -mcfsp
-dart run <app>:artisan make:model Order --all
+dart run magic:artisan make:model User
+dart run magic:artisan make:model Post --migration --controller --factory
+dart run magic:artisan make:model Comment -mcf
+dart run magic:artisan make:model Product -mcfsp
+dart run magic:artisan make:model Order --all
 ```
 
 #### Options
@@ -143,11 +143,11 @@ dart run <app>:artisan make:model Order --all
 Creates a controller class:
 
 ```bash
-dart run <app>:artisan make:controller User
-dart run <app>:artisan make:controller UserController
-dart run <app>:artisan make:controller Admin/Dashboard
-dart run <app>:artisan make:controller Post --resource
-dart run <app>:artisan make:controller Post --resource --model=Post
+dart run magic:artisan make:controller User
+dart run magic:artisan make:controller UserController
+dart run magic:artisan make:controller Admin/Dashboard
+dart run magic:artisan make:controller Post --resource
+dart run magic:artisan make:controller Post --resource --model=Post
 ```
 
 #### Options
@@ -165,10 +165,10 @@ dart run <app>:artisan make:controller Post --resource --model=Post
 Creates a view class:
 
 ```bash
-dart run <app>:artisan make:view Login
-dart run <app>:artisan make:view LoginView
-dart run <app>:artisan make:view Auth/Register
-dart run <app>:artisan make:view Dashboard --stateful
+dart run magic:artisan make:view Login
+dart run magic:artisan make:view LoginView
+dart run magic:artisan make:view Auth/Register
+dart run magic:artisan make:view Dashboard --stateful
 ```
 
 #### Options
@@ -185,9 +185,9 @@ dart run <app>:artisan make:view Dashboard --stateful
 Creates a timestamped database migration file:
 
 ```bash
-dart run <app>:artisan make:migration create_users_table
-dart run <app>:artisan make:migration create_users_table --create=users
-dart run <app>:artisan make:migration add_email_to_users --table=users
+dart run magic:artisan make:migration create_users_table
+dart run magic:artisan make:migration create_users_table --create=users
+dart run magic:artisan make:migration add_email_to_users --table=users
 ```
 
 #### Options
@@ -205,8 +205,8 @@ dart run <app>:artisan make:migration add_email_to_users --table=users
 Creates a database seeder:
 
 ```bash
-dart run <app>:artisan make:seeder User
-dart run <app>:artisan make:seeder UserSeeder
+dart run magic:artisan make:seeder User
+dart run magic:artisan make:seeder UserSeeder
 ```
 
 **Output:** `lib/database/seeders/<name>_seeder.dart`
@@ -217,8 +217,8 @@ dart run <app>:artisan make:seeder UserSeeder
 Creates a model factory for generating fake data:
 
 ```bash
-dart run <app>:artisan make:factory User
-dart run <app>:artisan make:factory UserFactory
+dart run magic:artisan make:factory User
+dart run magic:artisan make:factory UserFactory
 ```
 
 **Output:** `lib/database/factories/<name>_factory.dart`
@@ -229,10 +229,10 @@ dart run <app>:artisan make:factory UserFactory
 Creates an authorization policy:
 
 ```bash
-dart run <app>:artisan make:policy Post
-dart run <app>:artisan make:policy PostPolicy
-dart run <app>:artisan make:policy Post --model=Post
-dart run <app>:artisan make:policy Admin/Dashboard
+dart run magic:artisan make:policy Post
+dart run magic:artisan make:policy PostPolicy
+dart run magic:artisan make:policy Post --model=Post
+dart run magic:artisan make:policy Admin/Dashboard
 ```
 
 #### Options
@@ -249,8 +249,8 @@ dart run <app>:artisan make:policy Admin/Dashboard
 Creates a service provider class with `register()` and `boot()` stubs:
 
 ```bash
-dart run <app>:artisan make:provider Payment
-dart run <app>:artisan make:provider PaymentServiceProvider
+dart run magic:artisan make:provider Payment
+dart run magic:artisan make:provider PaymentServiceProvider
 ```
 
 The `ServiceProvider` suffix is appended automatically when omitted.
@@ -263,8 +263,8 @@ The `ServiceProvider` suffix is appended automatically when omitted.
 Creates a middleware class:
 
 ```bash
-dart run <app>:artisan make:middleware EnsureAuthenticated
-dart run <app>:artisan make:middleware Admin/RoleCheck
+dart run magic:artisan make:middleware EnsureAuthenticated
+dart run magic:artisan make:middleware Admin/RoleCheck
 ```
 
 **Output:** `lib/app/middleware/<name>.dart`
@@ -275,8 +275,8 @@ dart run <app>:artisan make:middleware Admin/RoleCheck
 Creates a string-backed enum with `fromValue()` factory and `selectOptions` getter:
 
 ```bash
-dart run <app>:artisan make:enum MonitorType
-dart run <app>:artisan make:enum Status/OrderStatus
+dart run magic:artisan make:enum MonitorType
+dart run magic:artisan make:enum Status/OrderStatus
 ```
 
 **Output:** `lib/app/enums/<name>.dart`
@@ -287,8 +287,8 @@ dart run <app>:artisan make:enum Status/OrderStatus
 Creates a dispatchable event class that extends `MagicEvent`:
 
 ```bash
-dart run <app>:artisan make:event UserLoggedIn
-dart run <app>:artisan make:event Auth/TokenRefreshed
+dart run magic:artisan make:event UserLoggedIn
+dart run magic:artisan make:event Auth/TokenRefreshed
 ```
 
 **Output:** `lib/app/events/<name>.dart`
@@ -299,9 +299,9 @@ dart run <app>:artisan make:event Auth/TokenRefreshed
 Creates an event listener class that extends `MagicListener<TEvent>`:
 
 ```bash
-dart run <app>:artisan make:listener AuthRestore
-dart run <app>:artisan make:listener AuthRestore --event=UserLoggedInEvent
-dart run <app>:artisan make:listener Auth/RestoreSession
+dart run magic:artisan make:listener AuthRestore
+dart run magic:artisan make:listener AuthRestore --event=UserLoggedInEvent
+dart run magic:artisan make:listener Auth/RestoreSession
 ```
 
 #### Options
@@ -318,8 +318,8 @@ dart run <app>:artisan make:listener Auth/RestoreSession
 Creates a form request class with a typed `rules()` method for request validation:
 
 ```bash
-dart run <app>:artisan make:request StoreMonitor
-dart run <app>:artisan make:request StoreMonitorRequest
+dart run magic:artisan make:request StoreMonitor
+dart run magic:artisan make:request StoreMonitorRequest
 ```
 
 The `Request` suffix is appended automatically when omitted.
@@ -332,9 +332,9 @@ The `Request` suffix is appended automatically when omitted.
 Creates a language JSON file:
 
 ```bash
-dart run <app>:artisan make:lang tr
-dart run <app>:artisan make:lang es
-dart run <app>:artisan make:lang de
+dart run magic:artisan make:lang tr
+dart run magic:artisan make:lang es
+dart run magic:artisan make:lang de
 ```
 
 **Output:** `assets/lang/<locale>.json`

--- a/doc/security/authorization.md
+++ b/doc/security/authorization.md
@@ -332,9 +332,9 @@ Register in `config/app.dart`:
 Use Magic CLI to generate policy classes:
 
 ```bash
-dart run <app>:artisan make:policy Post
-dart run <app>:artisan make:policy PostPolicy          # Explicit naming
-dart run <app>:artisan make:policy Comment --model=Comment
+dart run magic:artisan make:policy Post
+dart run magic:artisan make:policy PostPolicy          # Explicit naming
+dart run magic:artisan make:policy Comment --model=Comment
 ```
 
 ### Options

--- a/lib/src/cli/commands/magic_install_command.dart
+++ b/lib/src/cli/commands/magic_install_command.dart
@@ -97,9 +97,9 @@ typedef MainDartStrategyResult = ({
 /// ## Usage
 ///
 /// ```bash
-/// dart run :artisan magic:install
-/// dart run :artisan magic:install --without-auth --without-broadcasting
-/// dart run :artisan magic:install --force --non-interactive
+/// dart run magic:artisan magic:install
+/// dart run magic:artisan magic:install --without-auth --without-broadcasting
+/// dart run magic:artisan magic:install --force --non-interactive
 /// ```
 class MagicInstallCommand extends ArtisanInstallCommand {
   /// Public default constructor. Test fixtures subclass + override the four

--- a/skills/magic-framework/SKILL.md
+++ b/skills/magic-framework/SKILL.md
@@ -19,7 +19,7 @@ Three checks, each pays off across the whole session.
 
 1. **Read `lib/main.dart` and `lib/config/app.dart`.** Note the `providers` list and its ORDER (AppServiceProvider must precede AuthServiceProvider so `setUserFactory` is set before auth restore runs), and whether `configFactories` or `configs` is used.
 2. **Scan one existing controller + view pair in `lib/app/`** for the project's idioms: the singleton accessor shape, how views resolve controllers, how forms are wired. Match the surrounding code, do not invent a dialect.
-3. **Confirm the package name** (the `name:` in `pubspec.yaml`). The CLI invocation is `dart run <name>:artisan <cmd>`; `<app>` in this skill is that package name.
+3. **CLI invocation.** Magic ships an `artisan` executable, so every command runs as `dart run magic:artisan <cmd>` from any app that depends on magic (no package-name placeholder, no global activate).
 
 ## 1. Core Laws
 
@@ -330,17 +330,17 @@ Before reporting a magic task done, verify (with evidence, not assumption):
 
 ## 10. CLI
 
-The magic CLI is an `fluttersdk_artisan` plugin (`MagicArtisanProvider`); run it through the app's own artisan dispatcher. There is no `magic_cli` package and no global activation. `<app>` is the consumer package name.
+The magic CLI ships as an `artisan` executable in magic's `pubspec.yaml` (`executables: { artisan: }`, backed by `bin/artisan.dart`). Once magic is a dependency, run any command with `dart run magic:artisan <cmd>`. There is no `magic_cli` package and no global activation.
 
 ```bash
-dart run <app>:artisan magic:install                  # scaffold project structure
-dart run <app>:artisan make:model User -mcfsp          # model (+ migration/controller/factory/seeder/policy via flags)
-dart run <app>:artisan make:controller User -r         # resource controller
-dart run <app>:artisan make:view Login --stateful      # stateful view
-dart run <app>:artisan make:migration create_users     # migration
-dart run <app>:artisan make:request StoreUser          # form request
-dart run <app>:artisan make:policy User                # authorization policy
-dart run <app>:artisan key:generate                    # APP_KEY
+dart run magic:artisan magic:install                  # scaffold project structure
+dart run magic:artisan make:model User -mcfsp          # model (+ migration/controller/factory/seeder/policy via flags)
+dart run magic:artisan make:controller User -r         # resource controller
+dart run magic:artisan make:view Login --stateful      # stateful view
+dart run magic:artisan make:migration create_users     # migration
+dart run magic:artisan make:request StoreUser          # form request
+dart run magic:artisan make:policy User                # authorization policy
+dart run magic:artisan key:generate                    # APP_KEY
 ```
 
 Other generators: `make:seeder`, `make:factory`, `make:middleware`, `make:provider`, `make:event`, `make:listener`, `make:enum`, `make:lang`. Generators accept `--force` and nested paths (`Admin/Dashboard`). Full reference: `${CLAUDE_SKILL_DIR}/references/cli-commands.md`.

--- a/skills/magic-framework/references/cli-commands.md
+++ b/skills/magic-framework/references/cli-commands.md
@@ -4,39 +4,39 @@ Complete reference for the Magic CLI — an Artisan-inspired code generation and
 
 ## Invocation
 
-All commands are invoked via `dart run <app>:artisan <command>` from the Flutter project root (where `pubspec.yaml` lives). The magic CLI is an `fluttersdk_artisan` plugin (`MagicArtisanProvider`) that ships inside the magic package and runs through the host app's own artisan dispatcher. There is no separate `magic_cli` package and no global activation: `<app>` is the consumer app's package name (the `name:` in its `pubspec.yaml`).
+All commands are invoked via `dart run magic:artisan <command>` from the Flutter project root (where `pubspec.yaml` lives). Magic declares an `artisan` executable in its `pubspec.yaml` (`executables: { artisan: }`, backed by `bin/artisan.dart`), so once `magic` is a dependency the command works with no global activation and no app-specific package name. The commands come from `MagicArtisanProvider`, which also contributes to a consumer app's own aggregated artisan dispatcher when one exists.
 
 ## Command Overview
 
 | Category | Command | Description |
 |:---------|:--------|:------------|
-| **Setup** | `dart run <app>:artisan magic:install` | Initialize Magic in a Flutter project |
-| **Setup** | `dart run <app>:artisan key:generate` | Generate `APP_KEY` for encryption |
-| **Generator** | `dart run <app>:artisan make:model Name` | Eloquent model with optional related files |
-| **Generator** | `dart run <app>:artisan make:controller Name` | Controller (basic or resource) |
-| **Generator** | `dart run <app>:artisan make:view Name` | View class (stateless or stateful) |
-| **Generator** | `dart run <app>:artisan make:migration name` | Database migration |
-| **Generator** | `dart run <app>:artisan make:enum Name` | String-backed enum with `fromValue()` |
-| **Generator** | `dart run <app>:artisan make:event Name` | Event class extending `MagicEvent` |
-| **Generator** | `dart run <app>:artisan make:listener Name` | Listener class extending `MagicListener` |
-| **Generator** | `dart run <app>:artisan make:middleware Name` | Route middleware extending `MagicMiddleware` |
-| **Generator** | `dart run <app>:artisan make:factory Name` | Model factory for seeding/testing |
-| **Generator** | `dart run <app>:artisan make:seeder Name` | Database seeder |
-| **Generator** | `dart run <app>:artisan make:provider Name` | Service provider |
-| **Generator** | `dart run <app>:artisan make:policy Name` | Authorization policy with Gate definitions |
-| **Generator** | `dart run <app>:artisan make:request Name` | Form request (validation rules class) |
-| **Generator** | `dart run <app>:artisan make:lang code` | JSON language file |
+| **Setup** | `dart run magic:artisan magic:install` | Initialize Magic in a Flutter project |
+| **Setup** | `dart run magic:artisan key:generate` | Generate `APP_KEY` for encryption |
+| **Generator** | `dart run magic:artisan make:model Name` | Eloquent model with optional related files |
+| **Generator** | `dart run magic:artisan make:controller Name` | Controller (basic or resource) |
+| **Generator** | `dart run magic:artisan make:view Name` | View class (stateless or stateful) |
+| **Generator** | `dart run magic:artisan make:migration name` | Database migration |
+| **Generator** | `dart run magic:artisan make:enum Name` | String-backed enum with `fromValue()` |
+| **Generator** | `dart run magic:artisan make:event Name` | Event class extending `MagicEvent` |
+| **Generator** | `dart run magic:artisan make:listener Name` | Listener class extending `MagicListener` |
+| **Generator** | `dart run magic:artisan make:middleware Name` | Route middleware extending `MagicMiddleware` |
+| **Generator** | `dart run magic:artisan make:factory Name` | Model factory for seeding/testing |
+| **Generator** | `dart run magic:artisan make:seeder Name` | Database seeder |
+| **Generator** | `dart run magic:artisan make:provider Name` | Service provider |
+| **Generator** | `dart run magic:artisan make:policy Name` | Authorization policy with Gate definitions |
+| **Generator** | `dart run magic:artisan make:request Name` | Form request (validation rules class) |
+| **Generator** | `dart run magic:artisan make:lang code` | JSON language file |
 
 
 ## Project Setup
 
-### `dart run <app>:artisan magic:install`
+### `dart run magic:artisan magic:install`
 
 Initializes Magic in an existing Flutter project. Creates the full directory structure, configuration files, service providers, routes, and `main.dart` bootstrap.
 
 ```bash
-dart run <app>:artisan magic:install
-dart run <app>:artisan magic:install --without-database --without-events
+dart run magic:artisan magic:install
+dart run magic:artisan magic:install --without-database --without-events
 ```
 
 | Flag | Effect |
@@ -85,13 +85,13 @@ lib/
 └── main.dart                 # Bootstrap with Magic.init()
 ```
 
-### `dart run <app>:artisan key:generate`
+### `dart run magic:artisan key:generate`
 
 Generates a random 32-byte encryption key (base64-encoded) and writes it to `.env`.
 
 ```bash
-dart run <app>:artisan key:generate
-dart run <app>:artisan key:generate --show    # Display without writing to .env
+dart run magic:artisan key:generate
+dart run magic:artisan key:generate --show    # Display without writing to .env
 ```
 
 Updates your `.env`:
@@ -110,22 +110,22 @@ Required for the `Crypt` facade and encryption operations.
 
 All generators share these conventions:
 
-- **Auto-suffix**: `dart run <app>:artisan make:controller User` → `UserController`. The suffix is appended if not already present; existing suffixes are detected and not doubled.
-- **Nested paths**: `dart run <app>:artisan make:controller Admin/Dashboard` → `lib/app/controllers/admin/dashboard_controller.dart`. Directory segments are converted to snake_case.
+- **Auto-suffix**: `dart run magic:artisan make:controller User` → `UserController`. The suffix is appended if not already present; existing suffixes are detected and not doubled.
+- **Nested paths**: `dart run magic:artisan make:controller Admin/Dashboard` → `lib/app/controllers/admin/dashboard_controller.dart`. Directory segments are converted to snake_case.
 - **`--force` flag**: All generators accept `--force` to overwrite existing files.
 - **Import statement**: Generated files automatically import `package:magic/magic.dart`.
 
-### `dart run <app>:artisan make:model`
+### `dart run magic:artisan make:model`
 
 Creates an Eloquent model with optional companion files.
 
 ```bash
-dart run <app>:artisan make:model Monitor
-dart run <app>:artisan make:model Monitor -m          # + migration
-dart run <app>:artisan make:model Monitor -mc         # + migration + controller
-dart run <app>:artisan make:model Monitor -mcf        # + migration + controller + factory
-dart run <app>:artisan make:model Monitor -mcfsp      # + migration + controller + factory + seeder + policy
-dart run <app>:artisan make:model Monitor -a          # all companion files
+dart run magic:artisan make:model Monitor
+dart run magic:artisan make:model Monitor -m          # + migration
+dart run magic:artisan make:model Monitor -mc         # + migration + controller
+dart run magic:artisan make:model Monitor -mcf        # + migration + controller + factory
+dart run magic:artisan make:model Monitor -mcfsp      # + migration + controller + factory + seeder + policy
+dart run magic:artisan make:model Monitor -a          # all companion files
 ```
 
 | Flag | Short | Generates |
@@ -161,14 +161,14 @@ class Monitor extends Model with HasTimestamps, InteractsWithPersistence {
 }
 ```
 
-### `dart run <app>:artisan make:controller`
+### `dart run magic:artisan make:controller`
 
 Creates a controller class.
 
 ```bash
-dart run <app>:artisan make:controller Monitor
-dart run <app>:artisan make:controller Monitor --resource    # CRUD resource controller
-dart run <app>:artisan make:controller Admin/Dashboard       # Nested path
+dart run magic:artisan make:controller Monitor
+dart run magic:artisan make:controller Monitor --resource    # CRUD resource controller
+dart run magic:artisan make:controller Admin/Dashboard       # Nested path
 ```
 
 | Flag | Short | Effect |
@@ -191,14 +191,14 @@ class MonitorController extends MagicController {
 
 **Resource controller stub** (with `--resource`): Includes full CRUD methods — `index()`, `create()`, `show()`, `edit()`, `store()`, `update()`, `destroy()` — with API integration scaffolding.
 
-### `dart run <app>:artisan make:view`
+### `dart run magic:artisan make:view`
 
 Creates a view widget.
 
 ```bash
-dart run <app>:artisan make:view Login
-dart run <app>:artisan make:view Login --stateful    # With initState/dispose lifecycle
-dart run <app>:artisan make:view Auth/Register       # Nested path
+dart run magic:artisan make:view Login
+dart run magic:artisan make:view Login --stateful    # With initState/dispose lifecycle
+dart run magic:artisan make:view Auth/Register       # Nested path
 ```
 
 | Flag | Effect |
@@ -224,14 +224,14 @@ class LoginView extends StatelessWidget {
 
 **Stateful stub** (with `--stateful`): Generates `StatefulWidget` with `initState()` for resource setup and `dispose()` for cleanup.
 
-### `dart run <app>:artisan make:migration`
+### `dart run magic:artisan make:migration`
 
 Creates a database migration file with a timestamp prefix.
 
 ```bash
-dart run <app>:artisan make:migration create_monitors_table
-dart run <app>:artisan make:migration add_status_to_monitors_table
-dart run <app>:artisan make:migration create_monitors_table --create=monitors
+dart run magic:artisan make:migration create_monitors_table
+dart run magic:artisan make:migration add_status_to_monitors_table
+dart run magic:artisan make:migration create_monitors_table --create=monitors
 ```
 
 | Flag | Short | Effect |
@@ -265,13 +265,13 @@ class CreateMonitorsTable extends Migration {
 }
 ```
 
-### `dart run <app>:artisan make:enum`
+### `dart run magic:artisan make:enum`
 
 Creates a string-backed enum with `fromValue()` lookup and `selectOptions` getter.
 
 ```bash
-dart run <app>:artisan make:enum MonitorStatus
-dart run <app>:artisan make:enum Status/OrderStatus       # Nested path
+dart run magic:artisan make:enum MonitorStatus
+dart run magic:artisan make:enum Status/OrderStatus       # Nested path
 ```
 
 **Output**: `lib/app/enums/monitor_status.dart`
@@ -304,13 +304,13 @@ enum MonitorStatus {
 }
 ```
 
-### `dart run <app>:artisan make:event`
+### `dart run magic:artisan make:event`
 
 Creates an event class for the pub/sub system.
 
 ```bash
-dart run <app>:artisan make:event MonitorCreated
-dart run <app>:artisan make:event Auth/TokenRefreshed     # Nested path
+dart run magic:artisan make:event MonitorCreated
+dart run magic:artisan make:event Auth/TokenRefreshed     # Nested path
 ```
 
 **Output**: `lib/app/events/monitor_created.dart`
@@ -325,14 +325,14 @@ class MonitorCreated extends MagicEvent {
 }
 ```
 
-### `dart run <app>:artisan make:listener`
+### `dart run magic:artisan make:listener`
 
 Creates an event listener.
 
 ```bash
-dart run <app>:artisan make:listener SendMonitorNotification
-dart run <app>:artisan make:listener SendNotification --event=MonitorCreated
-dart run <app>:artisan make:listener Auth/RestoreSession   # Nested path
+dart run magic:artisan make:listener SendMonitorNotification
+dart run magic:artisan make:listener SendNotification --event=MonitorCreated
+dart run magic:artisan make:listener Auth/RestoreSession   # Nested path
 ```
 
 | Flag | Short | Effect |
@@ -354,13 +354,13 @@ class SendMonitorNotification extends MagicListener<MagicEvent> {
 }
 ```
 
-### `dart run <app>:artisan make:middleware`
+### `dart run magic:artisan make:middleware`
 
 Creates a route middleware.
 
 ```bash
-dart run <app>:artisan make:middleware EnsureAuthenticated
-dart run <app>:artisan make:middleware Admin/RoleCheck     # Nested path
+dart run magic:artisan make:middleware EnsureAuthenticated
+dart run magic:artisan make:middleware Admin/RoleCheck     # Nested path
 ```
 
 **Output**: `lib/app/middleware/ensure_authenticated.dart`
@@ -380,13 +380,13 @@ class EnsureAuthenticated extends MagicMiddleware {
 }
 ```
 
-### `dart run <app>:artisan make:factory`
+### `dart run magic:artisan make:factory`
 
 Creates a model factory for testing and seeding.
 
 ```bash
-dart run <app>:artisan make:factory Monitor        # Auto-appends 'Factory'
-dart run <app>:artisan make:factory MonitorFactory # No double-suffix
+dart run magic:artisan make:factory Monitor        # Auto-appends 'Factory'
+dart run magic:artisan make:factory MonitorFactory # No double-suffix
 ```
 
 **Output**: `lib/database/factories/monitor_factory.dart`
@@ -411,13 +411,13 @@ class MonitorFactory extends Factory<Model> {
 }
 ```
 
-### `dart run <app>:artisan make:seeder`
+### `dart run magic:artisan make:seeder`
 
 Creates a database seeder.
 
 ```bash
-dart run <app>:artisan make:seeder User           # Auto-appends 'Seeder'
-dart run <app>:artisan make:seeder UserSeeder     # No double-suffix
+dart run magic:artisan make:seeder User           # Auto-appends 'Seeder'
+dart run magic:artisan make:seeder UserSeeder     # No double-suffix
 ```
 
 **Output**: `lib/database/seeders/user_seeder.dart`
@@ -436,13 +436,13 @@ class UserSeeder extends Seeder {
 }
 ```
 
-### `dart run <app>:artisan make:provider`
+### `dart run magic:artisan make:provider`
 
 Creates a service provider.
 
 ```bash
-dart run <app>:artisan make:provider Payment             # Auto-appends 'ServiceProvider'
-dart run <app>:artisan make:provider PaymentServiceProvider # No double-suffix
+dart run magic:artisan make:provider Payment             # Auto-appends 'ServiceProvider'
+dart run magic:artisan make:provider PaymentServiceProvider # No double-suffix
 ```
 
 **Output**: `lib/app/providers/payment_service_provider.dart`
@@ -467,14 +467,14 @@ class PaymentServiceProvider extends ServiceProvider {
 }
 ```
 
-### `dart run <app>:artisan make:policy`
+### `dart run magic:artisan make:policy`
 
 Creates an authorization policy with Gate definitions.
 
 ```bash
-dart run <app>:artisan make:policy Monitor              # Auto-appends 'Policy'
-dart run <app>:artisan make:policy MonitorPolicy        # No double-suffix
-dart run <app>:artisan make:policy Monitor --model=Monitor
+dart run magic:artisan make:policy Monitor              # Auto-appends 'Policy'
+dart run magic:artisan make:policy MonitorPolicy        # No double-suffix
+dart run magic:artisan make:policy Monitor --model=Monitor
 ```
 
 | Flag | Short | Effect |
@@ -485,13 +485,13 @@ dart run <app>:artisan make:policy Monitor --model=Monitor
 
 **Generated stub:** Includes policy methods for authorization checks and Gate definitions.
 
-### `dart run <app>:artisan make:request`
+### `dart run magic:artisan make:request`
 
 Creates a form request class for validation.
 
 ```bash
-dart run <app>:artisan make:request StoreMonitor          # Auto-appends 'Request'
-dart run <app>:artisan make:request StoreMonitorRequest   # No double-suffix
+dart run magic:artisan make:request StoreMonitor          # Auto-appends 'Request'
+dart run magic:artisan make:request StoreMonitorRequest   # No double-suffix
 ```
 
 **Output**: `lib/app/validation/requests/store_monitor_request.dart`
@@ -512,13 +512,13 @@ class StoreMonitorRequest extends FormRequest {
 }
 ```
 
-### `dart run <app>:artisan make:lang`
+### `dart run magic:artisan make:lang`
 
 Creates a JSON language/translation file.
 
 ```bash
-dart run <app>:artisan make:lang tr
-dart run <app>:artisan make:lang en
+dart run magic:artisan make:lang tr
+dart run magic:artisan make:lang en
 ```
 
 **Output**: `assets/lang/tr.json`
@@ -539,7 +539,7 @@ flutter:
 Generate all companion files for a new resource with chained `-mcfsp` flags:
 
 ```bash
-dart run <app>:artisan make:model Monitor -mcfsp
+dart run magic:artisan make:model Monitor -mcfsp
 ```
 
 This creates:
@@ -553,7 +553,7 @@ This creates:
 Or use the shorthand:
 
 ```bash
-dart run <app>:artisan make:model Monitor --all
+dart run magic:artisan make:model Monitor --all
 ```
 
 ### Nested Paths
@@ -561,10 +561,10 @@ dart run <app>:artisan make:model Monitor --all
 Organize files into subdirectories:
 
 ```bash
-dart run <app>:artisan make:controller Admin/Dashboard
+dart run magic:artisan make:controller Admin/Dashboard
 # → lib/app/controllers/admin/dashboard_controller.dart
 
-dart run <app>:artisan make:view Settings/Profile
+dart run magic:artisan make:view Settings/Profile
 # → lib/resources/views/settings/profile_view.dart
 ```
 
@@ -575,8 +575,8 @@ Directory segments are automatically converted to snake_case in filenames.
 Combine flags for automatic resource controller generation with model binding:
 
 ```bash
-dart run <app>:artisan make:model Monitor -c --all
-dart run <app>:artisan make:controller Monitor --resource --model=Monitor
+dart run magic:artisan make:model Monitor -c --all
+dart run magic:artisan make:controller Monitor --resource --model=Monitor
 ```
 
 ## Gotchas

--- a/skills/magic-framework/references/forms-validation.md
+++ b/skills/magic-framework/references/forms-validation.md
@@ -501,7 +501,7 @@ Pair with `Model.fill(validated, strict: true)` to catch schema drift at the bou
 
 ### CLI
 
-Generate a FormRequest with: `dart run <app>:artisan make:request StoreUser`.
+Generate a FormRequest with: `dart run magic:artisan make:request StoreUser`.
 
 
 ## AsyncRule & Unique


### PR DESCRIPTION
## Summary

Aligns all documentation with the framework's intended CLI convention: **`dart run magic:artisan <command>`**.

Magic declares an `artisan` executable in its `pubspec.yaml` (`executables: { artisan: }`, backed by `bin/artisan.dart`, which boots `runArtisan` with `MagicArtisanProvider`). So once a user adds `magic` as a dependency, the full CLI is available via `dart run magic:artisan <cmd>` with **no global activation and no app-specific `<app>` package-name placeholder**. The source already used this form; the docs lagged behind (`dart run <app>:artisan` and stray `dart run magic:magic`).

## Changes

- **Uniform invocation swap** across `doc/**`, `README.md`, `skills/magic-framework/**`, `CLAUDE.md`, and a `lib/` dartdoc: `dart run <app>:artisan` / `dart run magic:magic` / `dart run :artisan` -> `dart run magic:artisan`.
- **Prose rewritten** where it explained the old model: the `<app>` placeholder ("replace with your package name"), the "host app's own artisan dispatcher" framing, and the stale `dart pub global activate magic_cli` tip now describe the bundled `artisan` executable.
- **README Quick Start simplified**: dropped the obsolete "Step 3: create `bin/artisan.dart`" (magic ships it) and renumbered; bootstrap is now just `dart run magic:artisan magic:install`.
- **Fixes**: a wrong command name in `CLAUDE.local.md` (`magic:make:controller` -> `make:controller`, local-only file) and the `MagicInstallCommand` dartdoc examples (`dart run :artisan` -> `dart run magic:artisan`).

## Verification (local)

- 0 residual `dart run <app>:artisan`, `magic:magic`, `dart run :artisan`, `magic:make:`, or `<app>` placeholders across docs/skill/README/CLAUDE/lib.
- lychee offline (`--root-dir doc --fallback-extensions md`): 476 OK, 0 errors.
- TOC/anchor check: 0 issues across 44 pages.
- `dart analyze` + `dart format` clean on the touched `lib/` file.

## Note

The install command keeps its registered name `magic:install`, so the bootstrap reads `dart run magic:artisan magic:install` ("magic" appears twice). That is accurate to the current command name; renaming it to a bare `install` would be a separate code change (it would also affect the aggregated `<app>:artisan magic:install` form). Flagging in case you want that follow-up.