### PR TITLE
chore(deps): bump fluttersdk_wind to ^1.1.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 Laravel-inspired Flutter framework: IoC container, 18 facades, Eloquent-style ORM, service providers, routing, auth, validation, broadcasting. UI is `fluttersdk_wind`; CLI + scaffolding run on `fluttersdk_artisan`.
 
-**Stack:** Dart >=3.11.0 · Flutter >=3.41.0. Runtime deps: `fluttersdk_wind ^1.0.0`, `fluttersdk_artisan ^0.0.8`, `dio`, `go_router`, `sqlite3`, `flutter_secure_storage`, `encrypt`. No `mockito` (mock via contract inheritance), no code generation.
+**Stack:** Dart >=3.11.0 · Flutter >=3.41.0. Runtime deps: `fluttersdk_wind ^1.1.1`, `fluttersdk_artisan ^0.0.8`, `dio`, `go_router`, `sqlite3`, `flutter_secure_storage`, `encrypt`. No `mockito` (mock via contract inheritance), no code generation.
 **Branch:** `master` is the active **0.0.x** development line — what pub.dev resolves. Pre-1.0: breaking changes are allowed; `1.0.0` is the future stable milestone. Direct pushes blocked; everything lands via PR.
 
 The dev-tooling adapters (`MagicDuskIntegration`, `MagicTelescopeIntegration`) live in the sibling `magic_devtools` package; magic core has zero dependency on `fluttersdk_dusk` / `fluttersdk_telescope`. CLI/scaffolding internals: `CLAUDE.local.md`. LLM-agent surface: `skills/magic-framework/SKILL.md`. Consumer overview: `README.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **`fluttersdk_wind` constraint bumped to `^1.1.1`.** Picks up wind 1.1.0's Material-free `WInput`/`WText` rewrite plus 1.1.1's two fixes that magic's W-widget UI depends on: `WInput` native text selection restored (mouse drag-select, double-tap word, long-press), and `WText` now inherits an ancestor `DefaultTextStyle` color (the CSS text-color cascade) before falling back to the OS-brightness baseline. The latter fixes invisible labels on magic's W-rendered surfaces (`Magic*View`, `MagicFeedback`, dialog buttons whose color lives on the container) when the app theme disagrees with the OS theme. Touches `pubspec.yaml`.
 - **Debug-tooling install guidance corrected to regular `dependencies`.** The `magic:install` post-install message recommended adding `magic_devtools` / `fluttersdk_dusk` / `fluttersdk_telescope` to `dev_dependencies`, but the install commands wire them into `lib/main.dart` (under `kDebugMode`), which trips the `depend_on_referenced_packages` lint. They are now documented as regular `dependencies` (tree-shaken from release via `kDebugMode`), matching dusk/telescope's own install docs. Also bumps the message's stale `fluttersdk_dusk ^0.0.7` to `^0.0.8`. Touches `install.yaml`.
 
 ## [0.0.3] - 2026-06-17

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Laravel-inspired Flutter framework: IoC container, 18 facades, Eloquent-style ORM, service providers, routing, auth, validation, broadcasting. UI is `fluttersdk_wind`; CLI + scaffolding run on `fluttersdk_artisan`.
 
-**Stack:** Dart >=3.11.0 · Flutter >=3.41.0. Runtime deps: `fluttersdk_wind ^1.0.0`, `fluttersdk_artisan ^0.0.8`, `dio`, `go_router`, `sqlite3`, `flutter_secure_storage`, `encrypt`. No `mockito` (mock via contract inheritance), no code generation.
+**Stack:** Dart >=3.11.0 · Flutter >=3.41.0. Runtime deps: `fluttersdk_wind ^1.1.1`, `fluttersdk_artisan ^0.0.8`, `dio`, `go_router`, `sqlite3`, `flutter_secure_storage`, `encrypt`. No `mockito` (mock via contract inheritance), no code generation.
 **Branch:** `master` is the active **0.0.x** development line — what pub.dev resolves. Pre-1.0: breaking changes are allowed; `1.0.0` is the future stable milestone. Direct pushes blocked; everything lands via PR.
 
 The dev-tooling adapters (`MagicDuskIntegration`, `MagicTelescopeIntegration`) live in the sibling `magic_devtools` package; magic core has zero dependency on `fluttersdk_dusk` / `fluttersdk_telescope`. CLI/scaffolding internals: `CLAUDE.local.md`. LLM-agent surface: `skills/magic-framework/SKILL.md`. Consumer overview: `README.md`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  fluttersdk_wind: ^1.0.0
+  fluttersdk_wind: ^1.1.1
   meta: ^1.16.0
   more: ^4.7.0
   dio: ^5.9.0


### PR DESCRIPTION
## What

Bumps magic's `fluttersdk_wind` constraint from `^1.0.0` to `^1.1.1` (pubspec.yaml), plus the matching version stamps in `CLAUDE.md` and a `CHANGELOG.md` entry under `[Unreleased] → Changed`.

## Why

wind 1.1.1 ships two fixes that magic's W-widget UI depends on:

- **`WInput` native text selection restored** (mouse drag-select, double-tap word, long-press). The 1.1.0 Material-free rewrite had dropped the selection gesture layer.
- **`WText` ancestor-color cascade** (CSS text-color cascade): colorless text now inherits a parent `DefaultTextStyle` color before falling back to the OS-brightness baseline. Fixes invisible labels on magic's W-rendered surfaces (`Magic*View`, `MagicFeedback`, dialog buttons whose color lives on the container) when the app theme disagrees with the OS theme.

`^1.0.0` already permitted 1.1.1, so the resolved dependency graph is unchanged from what CI runs on master; this raises the floor to guarantee the fixes for downstream consumers (magic_starter, magic_social_auth, etc. all inherit wind transitively through magic, so no direct edits are needed there).

## Verification

- `flutter pub get`: resolves `fluttersdk_wind 1.1.1` (hosted).
- `dart analyze`: no issues.
- `dart format --set-exit-if-changed .`: no diff.
- `flutter test`: 1158 passed.