### PR TITLE
chore(release): magic 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.0.6] - 2026-07-29
+
 ### Contributing checklist (before merging into `[Unreleased]`)
 
 - [ ] CHANGELOG entry added under the appropriate bucket (BREAKING / Added / Changed / Removed / Fixed / Improvements)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -337,10 +337,10 @@ packages:
     dependency: "direct main"
     description:
       name: fluttersdk_artisan
-      sha256: "008a29e38629ee1295a601fc9146d976ecf642b93e6dbe6750a9336ed4cac05c"
+      sha256: c439ab7cdc9c7341c423e31b0fa1d303133d401e2aa0ab2e516086eb7fc7be5f
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.8"
+    version: "0.0.9"
   fluttersdk_wind:
     dependency: transitive
     description:
@@ -547,7 +547,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.5"
+    version: "0.0.6"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.9
   magic:
     path: ..
-    version: 0.0.5
+    version: 0.0.6
   fluttersdk_artisan: ^0.0.8
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic
 description: "A Laravel-inspired Flutter framework with Eloquent ORM, routing, and MVC architecture."
-version: 0.0.5
+version: 0.0.6
 homepage: https://magic.fluttersdk.com
 repository: https://github.com/fluttersdk/magic
 issue_tracker: https://github.com/fluttersdk/magic/issues
@@ -49,7 +49,7 @@ dependencies:
   faker: ^2.2.0
   web_socket_channel: ^3.0.0
   yaml: ^3.1.3
-  fluttersdk_artisan: ^0.0.8
+  fluttersdk_artisan: ^0.0.9
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
Cuts 0.0.6 with the runtime-locale and timezone-detection work merged in #112.

Two dependency mechanics, both of which fail the release if missed:

`fluttersdk_artisan` moves from `^0.0.8` to `^0.0.9`. Under pub's 0.0.z caret
semantics `^0.0.8` means `>=0.0.8 <0.0.9`, so it EXCLUDES the 0.0.9 just published;
leaving it would pin every magic consumer to the previous artisan. This is the
ordering constraint that makes the release train sequential rather than parallel.

`example/pubspec.yaml` pins the root package by version next to its `path: ..`
dependency, so that pin advances in the same commit. The publish workflow resolves
`example/` during validation and a stale pin fails version solving there, which is
exactly how the artisan release failed on its first attempt.

Verified against this repo's own gates: `dart format --set-exit-if-changed .` over
the WHOLE repo (magic gates everything, unlike artisan which gates only
`lib/ test/ bin/`), `flutter analyze` clean, 1282 tests passing, and both the root
and `example/` resolving with the bumped pins.