### PR TITLE
fix(ci): stop the weekly link check failing on the stargazers badge

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -10,6 +10,15 @@
 # GitHub login/auth walls (linked repos are public but auth redirects happen)
 https://github.com/login*
 
+# GitHub stargazers pages. These 404 for any unauthenticated non-browser client,
+# on every repository, not just ours: verified on 2026-08-03 against
+# flutter/flutter, fluttersdk/wind, and fluttersdk/magic, all of which return
+# 404 for /stargazers and 200 for the repo root. The README badge link is
+# therefore a permanent false positive that failed the weekly pass every week.
+# Listed as the literal URL rather than a wildcard because this repo links only
+# its own; add a sibling line if another stargazers link ever appears.
+https://github.com/fluttersdk/magic/stargazers
+
 # pub.dev search and analytics pages (rate-limited for CI IPs)
 https://pub.dev/packages*
 


### PR DESCRIPTION
## What

One line in `.lycheeignore`: `https://github.com/fluttersdk/magic/stargazers`.

## Why

The scheduled `External Links` pass fails on every run, always on the same URL:

```
### Errors in README.md
* [404] <https://github.com/fluttersdk/magic/stargazers> | Rejected status code: 404 Not Found
```

That is 1 error out of 521 links, and it is not a broken link. GitHub returns 404 for `/stargazers` to any unauthenticated non-browser client. Measured today:

| URL | `/stargazers` | repo root |
|:--|--:|--:|
| `flutter/flutter` | 404 | 200 |
| `fluttersdk/wind` | 404 | 200 |
| `fluttersdk/magic` | 404 | 200 |

So the badge link is correct and the checker cannot see it. A weekly job that is always red is worse than no job at all: it trains everyone to skip the one notification that would catch genuine external rot, which is exactly what this pass exists for.

Listed as the literal URL rather than a wildcard because this repo links only its own stargazers page, and a literal entry cannot misfire regardless of whether lychee treats the file's lines as globs or regexes.

## Testing

The per-PR job (`Internal Links & Anchors`, offline) covers this PR. The external pass only runs on a schedule or a manual trigger, so I will run `docs-link-check.yml` manually on `master` after merge and confirm the External Links job goes green.