### PR TITLE
docs(skill): add a Contents block to the 15 long reference files

### DIFF
--- a/skills/magic-framework/references/auth-system.md
+++ b/skills/magic-framework/references/auth-system.md
@@ -2,6 +2,18 @@
 
 Guard-based authentication with secure token storage, automatic session restoration, and authorization via Gate and Policies.
 
+## Contents
+
+- [Auth Facade](#auth-facade)
+- [Auth Configuration](#auth-configuration)
+- [Guards](#guards)
+- [Token Management](#token-management)
+- [Gate & Authorization](#gate--authorization)
+- [Authorization Widgets](#authorization-widgets)
+- [User Model: Authenticatable Mixin](#user-model-authenticatable-mixin)
+- [Auth Events](#auth-events)
+- [Gotchas](#gotchas)
+
 ## Auth Facade
 
 The `Auth` facade provides static access to the authentication system and proxies calls to the default guard.

--- a/skills/magic-framework/references/bootstrap-lifecycle.md
+++ b/skills/magic-framework/references/bootstrap-lifecycle.md
@@ -1,3 +1,7 @@
+# Bootstrap & Lifecycle
+
+How a Magic app comes up: the ordered stages of `Magic.init()`, the IoC container it fills, the register-then-boot split every ServiceProvider follows, where Env and Config resolve, and the reset discipline tests depend on.
+
 ## Contents
 
 - [Magic.init() Lifecycle](#magicinit-lifecycle)

--- a/skills/magic-framework/references/bootstrap-lifecycle.md
+++ b/skills/magic-framework/references/bootstrap-lifecycle.md
@@ -1,3 +1,13 @@
+## Contents
+
+- [Magic.init() Lifecycle](#magicinit-lifecycle)
+- [IoC Container (Magic.make, Magic.put, Magic.singleton)](#ioc-container-magicmake-magicput-magicsingleton)
+- [Controller Management](#controller-management)
+- [ServiceProvider Lifecycle](#serviceprovider-lifecycle)
+- [Environment & Configuration](#environment--configuration)
+- [Testing: Reset & Flush](#testing-reset--flush)
+- [Key Gotchas](#key-gotchas)
+
 ## Magic.init() Lifecycle
 
 The bootstrap process follows a strict sequence executed via `Magic.init()`:

--- a/skills/magic-framework/references/cli-commands.md
+++ b/skills/magic-framework/references/cli-commands.md
@@ -2,6 +2,15 @@
 
 Complete reference for the Magic CLI — an Artisan-inspired code generation and project management tool for Magic Framework projects.
 
+## Contents
+
+- [Invocation](#invocation)
+- [Command Overview](#command-overview)
+- [Project Setup](#project-setup)
+- [Code Generators](#code-generators)
+- [Common Patterns](#common-patterns)
+- [Gotchas](#gotchas)
+
 ## Invocation
 
 All commands are invoked via `dart run magic:artisan <command>` from the Flutter project root (where `pubspec.yaml` lives). Magic declares an `artisan` executable in its `pubspec.yaml` (`executables: { artisan: }`, backed by `bin/artisan.dart`), so once `magic` is a dependency the command works with no global activation and no app-specific package name. The commands come from `MagicArtisanProvider`, which also contributes to a consumer app's own aggregated artisan dispatcher when one exists.

--- a/skills/magic-framework/references/controllers-views.md
+++ b/skills/magic-framework/references/controllers-views.md
@@ -3,6 +3,20 @@
 Laravel-inspired UI architecture. Controllers manage state and business logic; Views observe and render.
 
 
+## Contents
+
+- [MagicController](#magiccontroller)
+- [MagicStateMixin\<T\>](#magicstatemixint)
+- [Singleton Accessor Pattern](#singleton-accessor-pattern)
+- [ValidatesRequests Mixin](#validatesrequests-mixin)
+- [ValueNotifier Pattern](#valuenotifier-pattern)
+- [MagicView\<T\>](#magicviewt)
+- [MagicStatefulView\<T\>](#magicstatefulviewt)
+- [MagicResponsiveView\<T\>](#magicresponsiveviewt)
+- [MagicBuilder\<T\>](#magicbuildert)
+- [Complete Lifecycle Example](#complete-lifecycle-example)
+- [Gotchas](#gotchas)
+
 ## MagicController
 
 Base class for all controllers. Extends `ChangeNotifier`.

--- a/skills/magic-framework/references/eloquent-orm.md
+++ b/skills/magic-framework/references/eloquent-orm.md
@@ -3,6 +3,24 @@
 Laravel-inspired ORM for Flutter. Supports hybrid persistence (Remote API + Local SQLite).
 
 
+## Contents
+
+- [Model Definition Template](#model-definition-template)
+- [Configuration Properties](#configuration-properties)
+- [Attribute API](#attribute-api)
+- [Casting](#casting)
+- [Mass Assignment & MassAssignmentException](#mass-assignment--massassignmentexception)
+- [Relations](#relations)
+- [Dirty Tracking](#dirty-tracking)
+- [HasTimestamps Mixin](#hastimestamps-mixin)
+- [InteractsWithPersistence Mixin](#interactswithpersistence-mixin)
+- [Hybrid Persistence Flow](#hybrid-persistence-flow)
+- [QueryBuilder](#querybuilder)
+- [Migrations](#migrations)
+- [Factories & Seeders](#factories--seeders)
+- [Model Events](#model-events)
+- [Gotchas](#gotchas)
+
 ## Model Definition Template
 
 Complete boilerplate for a model with timestamps and persistence:

--- a/skills/magic-framework/references/facades-api.md
+++ b/skills/magic-framework/references/facades-api.md
@@ -4,6 +4,28 @@ All facades are available after `await Magic.init()` completes. Import: `package
 
 ---
 
+## Contents
+
+- [Auth](#auth)
+- [Cache](#cache)
+- [Config](#config)
+- [Crypt](#crypt)
+- [DB](#db)
+- [Echo](#echo)
+- [Event](#event)
+- [Gate](#gate)
+- [Http](#http)
+- [Lang](#lang)
+- [Launch](#launch)
+- [Session](#session)
+- [Log](#log)
+- [Pick](#pick)
+- [Route](#route)
+- [Schema](#schema)
+- [Storage](#storage)
+- [Vault](#vault)
+- [Gotchas](#gotchas)
+
 ## Auth
 
 Proxies calls to the default guard via the `AuthManager` singleton.

--- a/skills/magic-framework/references/forms-validation.md
+++ b/skills/magic-framework/references/forms-validation.md
@@ -3,6 +3,23 @@
 Comprehensive guide to handling form state, validation rules, and server-side error mapping in the Magic framework.
 
 
+## Contents
+
+- [MagicFormData](#magicformdata)
+- [MagicForm Widget](#magicform-widget)
+- [rules() Helper (MagicStatefulViewState)](#rules-helper-magicstatefulviewstate)
+- [FormValidator.rules() (standalone)](#formvalidatorrules-standalone)
+- [Validator.make()](#validatormake)
+- [ValidatesRequests Mixin](#validatesrequests-mixin)
+- [Built-in Rules](#built-in-rules)
+- [Custom Rules](#custom-rules)
+- [Server Error Mapping](#server-error-mapping)
+- [Message i18n](#message-i18n)
+- [Full Form Workflow Example](#full-form-workflow-example)
+- [Gotchas](#gotchas)
+- [FormRequest](#formrequest)
+- [AsyncRule & Unique](#asyncrule--unique)
+
 ## MagicFormData
 
 The central manager for form state. It automatically infers the correct controller type based on the initial value provided in the map.

--- a/skills/magic-framework/references/http-network.md
+++ b/skills/magic-framework/references/http-network.md
@@ -7,6 +7,20 @@ Import via:
 import 'package:magic/magic.dart';
 ```
 
+## Contents
+
+- [Network Configuration](#network-configuration)
+- [Http Facade](#http-facade)
+- [MagicResponse API](#magicresponse-api)
+- [Validation Error Example](#validation-error-example)
+- [Interceptors](#interceptors)
+- [Driver Plugin Hook](#driver-plugin-hook)
+- [ValidatesRequests Mixin](#validatesrequests-mixin)
+- [MagicStateMixin Fetch Helpers](#magicstatemixin-fetch-helpers)
+- [Common Patterns](#common-patterns)
+- [Testing](#testing)
+- [Gotchas](#gotchas)
+
 ## Network Configuration
 
 Defined in `lib/config/network.dart`. The default configuration uses the `api` driver.

--- a/skills/magic-framework/references/plugin-deeplink.md
+++ b/skills/magic-framework/references/plugin-deeplink.md
@@ -4,6 +4,19 @@
 
 Deep link handling plugin for Magic Framework: wraps `app_links` with a handler chain, IoC binding, and CLI tooling for generating server-side verification files.
 
+## Contents
+
+- [Installation](#installation)
+- [DeeplinkManager API](#deeplinkmanager-api)
+- [Contracts](#contracts)
+- [Built-in Implementations](#built-in-implementations)
+- [Configuration](#configuration)
+- [ServiceProvider](#serviceprovider)
+- [CLI Commands](#cli-commands)
+- [Usage Patterns](#usage-patterns)
+- [Testing](#testing)
+- [Gotchas](#gotchas)
+
 ## Installation
 
 ```bash

--- a/skills/magic-framework/references/plugin-notifications.md
+++ b/skills/magic-framework/references/plugin-notifications.md
@@ -4,6 +4,20 @@
 
 Push and in-app notification system for Magic Framework: the `Notify` facade, database (in-app) notifications with real-time streaming, OneSignal push integration, and background polling.
 
+## Contents
+
+- [Installation](#installation)
+- [CLI commands and MCP tools](#cli-commands-and-mcp-tools)
+- [Notify Facade API](#notify-facade-api)
+- [Contracts](#contracts)
+- [Channels](#channels)
+- [PushDriver](#pushdriver)
+- [Models](#models)
+- [Configuration](#configuration)
+- [Service Provider Setup](#service-provider-setup)
+- [Usage Patterns](#usage-patterns)
+- [Gotchas](#gotchas)
+
 ## Installation
 
 ```bash

--- a/skills/magic-framework/references/plugin-social-auth.md
+++ b/skills/magic-framework/references/plugin-social-auth.md
@@ -4,6 +4,22 @@
 
 Laravel Socialite-style social authentication for Magic Framework: Google, Microsoft, and GitHub out of the box with a pluggable driver system.
 
+## Contents
+
+- [Installation](#installation)
+- [Registration](#registration)
+- [SocialAuth Facade](#socialauth-facade)
+- [SocialAuthManager](#socialauthmanager)
+- [Built-in Drivers](#built-in-drivers)
+- [Contracts](#contracts)
+- [Models](#models)
+- [Configuration](#configuration)
+- [SocialAuthButtons Widget](#socialauthbuttons-widget)
+- [Custom Driver](#custom-driver)
+- [Custom Handler (e.g., Firebase)](#custom-handler-eg-firebase)
+- [Exceptions](#exceptions)
+- [Gotchas](#gotchas)
+
 ## Installation
 
 ```bash

--- a/skills/magic-framework/references/plugin-starter.md
+++ b/skills/magic-framework/references/plugin-starter.md
@@ -4,6 +4,22 @@
 
 Full-stack Flutter starter kit for Magic Framework: pre-built auth flows, team management, profile settings, notification UI, and responsive app/guest layouts with an opt-in feature flag system.
 
+## Contents
+
+- [Installation & Setup](#installation--setup)
+- [MagicStarter Facade API](#magicstarter-facade-api)
+- [Configuration](#configuration)
+- [View Registry](#view-registry)
+- [Reusable Widgets](#reusable-widgets)
+- [Session scope (cross-tenant leak guard)](#session-scope-cross-tenant-leak-guard)
+- [Route middleware](#route-middleware)
+- [Plan upgrade wall](#plan-upgrade-wall)
+- [Settings page width](#settings-page-width)
+- [Controllers](#controllers)
+- [Layouts & Notification Integration](#layouts--notification-integration)
+- [Gate Abilities](#gate-abilities)
+- [Gotchas](#gotchas)
+
 ## Installation & Setup
 
 ```bash

--- a/skills/magic-framework/references/routing-navigation.md
+++ b/skills/magic-framework/references/routing-navigation.md
@@ -2,6 +2,27 @@
 
 Comprehensive guide to route registration, context-free navigation, middleware, transitions, and persistent layouts in the Magic framework.
 
+## Contents
+
+- [Route Registration](#route-registration)
+- [Fluent Route Definition API](#fluent-route-definition-api)
+- [Route Groups](#route-groups)
+- [Resource Routes (ResourceController)](#resource-routes-resourcecontroller)
+- [Persistent Layouts (Shell Routes)](#persistent-layouts-shell-routes)
+- [Route Transitions](#route-transitions)
+- [Context-Free Navigation](#context-free-navigation)
+- [Path & Query Parameters](#path--query-parameters)
+- [Named Routes](#named-routes)
+- [Intended URL (Redirect-After-Login Pattern)](#intended-url-redirect-after-login-pattern)
+- [Middleware Pipeline](#middleware-pipeline)
+- [RouteServiceProvider Pattern](#routeserviceprovider-pattern)
+- [Router Configuration](#router-configuration)
+- [Key Patterns](#key-patterns)
+- [URL Strategy (Web)](#url-strategy-web)
+- [Navigator Observers](#navigator-observers)
+- [Page Titles](#page-titles)
+- [Gotchas](#gotchas)
+
 ## Route Registration
 
 Routes are registered using the `MagicRoute.page()` method. Each route maps a path to a widget builder function.

--- a/skills/magic-framework/references/secondary-systems.md
+++ b/skills/magic-framework/references/secondary-systems.md
@@ -2,6 +2,22 @@
 
 Complete reference for Magic framework utility systems: Cache, Events, Logging, Localization, Storage, Encryption, Vault, Carbon, Launch, and Pick. All systems are accessible through facades after importing `package:magic/magic.dart`.
 
+## Contents
+
+- [Cache System](#cache-system)
+- [Event Dispatcher](#event-dispatcher)
+- [Logging Manager](#logging-manager)
+- [Localization (Translator)](#localization-translator)
+- [Session (Flash Store)](#session-flash-store)
+- [Storage Manager](#storage-manager)
+- [Encryption (Crypt Facade)](#encryption-crypt-facade)
+- [Vault (Security Storage)](#vault-security-storage)
+- [Carbon (Date Manipulation)](#carbon-date-manipulation)
+- [Launch (URL Launcher)](#launch-url-launcher)
+- [Pick (File & Image Selection)](#pick-file--image-selection)
+- [Broadcasting](#broadcasting)
+- [Key Gotchas](#key-gotchas)
+
 ## Cache System
 
 The Cache system provides a unified key-value caching API with TTL (time-to-live) support. Backed by the `CacheManager` and resolved via the `Cache` facade.

--- a/skills/magic-framework/references/testing-patterns.md
+++ b/skills/magic-framework/references/testing-patterns.md
@@ -2,6 +2,24 @@
 
 Reference for testing Magic framework applications including service mocking, controller tests, model persistence, and UI integration.
 
+## Contents
+
+- [Essential setUp Pattern](#essential-setup-pattern)
+- [Controller Testing](#controller-testing)
+- [Model Testing](#model-testing)
+- [Mocking Services](#mocking-services)
+- [Test Bootstrap](#test-bootstrap)
+- [Http Faking](#http-faking)
+- [Facade Faking](#facade-faking)
+- [Middleware Testing](#middleware-testing)
+- [Validation Testing](#validation-testing)
+- [Integration Testing](#integration-testing)
+- [Test Directory Structure](#test-directory-structure)
+- [Common Testing Patterns](#common-testing-patterns)
+- [Common Gotchas](#common-gotchas)
+- [Running Tests](#running-tests)
+- [Imports](#imports)
+
 ## Essential setUp Pattern
 
 Every Magic test MUST reset the global state in `setUp()` to prevent state leakage between tests. This is non-negotiable.


### PR DESCRIPTION
## What

A `## Contents` block in the fifteen `references/*.md` files over 250 lines with six or more sections:

| File | Lines | Sections |
|:--|--:|--:|
| `testing-patterns.md` | 1295 | 15 |
| `secondary-systems.md` | 1096 | 13 |
| `cli-commands.md` | 679 | 6 |
| `facades-api.md` | 673 | 19 |
| `auth-system.md` | 599 | 9 |
| `plugin-starter.md` | 587 | 13 |
| `forms-validation.md` | 585 | 14 |
| `routing-navigation.md` | 582 | 18 |
| `http-network.md` | 578 | 11 |
| `controllers-views.md` | 506 | 11 |
| `eloquent-orm.md` | 432 | 15 |
| `bootstrap-lifecycle.md` | 392 | 7 |
| `plugin-notifications.md` | 385 | 11 |
| `plugin-social-auth.md` | 366 | 13 |
| `plugin-deeplink.md` | 299 | 10 |

## Why

These files are loaded on demand by an agent that has already decided it needs one of them, and the first thing it does is find the relevant part. With no map, a `head -100` on `testing-patterns.md` shows under a tenth of the file and none of its scope, so the agent either pulls 1,295 lines into context or answers from the fragment it happened to read. `templates.md` already had a Contents block; this makes the rest of the skill match it.

`community.md` (123 lines, 3 sections) and `plugin-devtools.md` (125 lines, 5 sections) are deliberately left alone: a table of contents longer than the section it introduces is noise.

## Testing

- Generated from each file's own `## ` headings, so a block cannot list a section that does not exist.
- Every link checked against GitHub's slug rule, which replaces each space with a hyphen and does not collapse runs (`## 10. Sentry / Bugsnag coexistence` is `#10-sentry--bugsnag-coexistence`, two hyphens). Across all five FlutterSDK skills that is 407 links in 37 files with a Contents block, **0 broken**.
- Content is otherwise untouched: the diff is 15 insertions of a block and nothing else.